### PR TITLE
Update relics that get played outside of Action Phase.

### DIFF
--- a/app/api/[gameId]/dataUpdate/route.ts
+++ b/app/api/[gameId]/dataUpdate/route.ts
@@ -93,6 +93,10 @@ import { SwapStrategyCardsHandler } from "../../../../src/util/model/swapStrateg
 import { UpdateLeaderStateHandler } from "../../../../src/util/model/updateLeaderState";
 import { UpdatePlanetStateHandler } from "../../../../src/util/model/updatePlanetState";
 import { NextResponse } from "next/server";
+import {
+  PlayRelicHandler,
+  UnplayRelicHandler,
+} from "../../../../src/util/model/playRelic";
 
 export async function POST(
   req: Request,
@@ -481,6 +485,14 @@ function updateInTransaction(
       }
       case "START_VOTING": {
         handler = new StartVotingHandler(gameData, data);
+        break;
+      }
+      case "PLAY_RELIC": {
+        handler = new PlayRelicHandler(gameData, data);
+        break;
+      }
+      case "UNPLAY_RELIC": {
+        handler = new UnplayRelicHandler(gameData, data);
         break;
       }
       case "UNDO": {

--- a/app/game/[gameId]/(faction)/[factionId]/faction-page.tsx
+++ b/app/game/[gameId]/(faction)/[factionId]/faction-page.tsx
@@ -37,6 +37,7 @@ import {
   ObjectiveContext,
   OptionContext,
   PlanetContext,
+  RelicContext,
   StateContext,
   StrategyCardContext,
   TechContext,
@@ -79,6 +80,7 @@ import {
 import {
   getActiveAgenda,
   getFactionVotes,
+  getPlayedRelic,
   getScoredObjectives,
   getSelectedEligibleOutcomes,
   getSpeakerTieBreak,
@@ -154,6 +156,7 @@ function PhaseSection({ factionId }: { factionId: FactionId }) {
   const planets = useContext(PlanetContext);
   const objectives = useContext(ObjectiveContext);
   const options = useContext(OptionContext);
+  const relics = useContext(RelicContext);
   const state = useContext(StateContext);
   const strategyCards = useContext(StrategyCardContext);
   const voteRef = useRef<HTMLDivElement>(null);
@@ -269,7 +272,7 @@ function PhaseSection({ factionId }: { factionId: FactionId }) {
   const ownedPlanets = filterToClaimedPlanets(planets, factionId);
   const updatedPlanets = applyAllPlanetAttachments(ownedPlanets, attachments);
 
-  const { influence, extraVotes } = computeRemainingVotes(
+  let { influence, extraVotes } = computeRemainingVotes(
     factionId,
     factions,
     planets,
@@ -279,6 +282,16 @@ function PhaseSection({ factionId }: { factionId: FactionId }) {
     state,
     getCurrentPhasePreviousLogEntries(actionLog)
   );
+  const mawOfWorlds = relics["Maw of Worlds"];
+  if (mawOfWorlds && mawOfWorlds.owner === factionId) {
+    const mawEvent: MawOfWorldsEvent | undefined = getPlayedRelic(
+      actionLog,
+      "Maw of Worlds"
+    ) as MawOfWorldsEvent | undefined;
+    if (mawEvent) {
+      influence = 0;
+    }
+  }
 
   const faction = factions[factionId];
   if (!faction) {

--- a/server/compiled-lang/en.json
+++ b/server/compiled-lang/en.json
@@ -101,6 +101,12 @@
       "value": "Leaders"
     }
   ],
+  "/lAAq/": [
+    {
+      "type": 0,
+      "value": "Score Crown of Emphidia?"
+    }
+  ],
   "/sF4zW": [
     {
       "type": 0,

--- a/server/lang/en.json
+++ b/server/lang/en.json
@@ -51,6 +51,10 @@
     "defaultMessage": "Leaders",
     "description": "Agent, commander, and hero cards."
   },
+  "/lAAq/": {
+    "defaultMessage": "Score Crown of Emphidia?",
+    "description": "Message asking if a specific player scored the Crown of Emphidia relic."
+  },
   "/sF4zW": {
     "defaultMessage": "Choose Starting Tech",
     "description": "Label on a hover menu used to select starting techs."

--- a/src/components/CrownOfEmphidia/CrownOfEmphidia.tsx
+++ b/src/components/CrownOfEmphidia/CrownOfEmphidia.tsx
@@ -1,0 +1,128 @@
+import { useContext } from "react";
+import {
+  ActionLogContext,
+  FactionContext,
+  GameIdContext,
+  PlanetContext,
+  RelicContext,
+} from "../../context/Context";
+import { playRelicAsync, unplayRelicAsync } from "../../dynamic/api";
+import { SymbolX } from "../../icons/svgs";
+import { getPlayedRelic } from "../../util/actionLog";
+import { getFactionColor, getFactionName } from "../../util/factions";
+import FactionIcon from "../FactionIcon/FactionIcon";
+import LabeledDiv from "../LabeledDiv/LabeledDiv";
+import { FormattedMessage } from "react-intl";
+
+export default function CrownOfEmphidia({}) {
+  const actionLog = useContext(ActionLogContext);
+  const factions = useContext(FactionContext);
+  const planets = useContext(PlanetContext);
+  const gameId = useContext(GameIdContext);
+  const relics = useContext(RelicContext);
+
+  const crownOfEmphidia = relics["The Crown of Emphidia"];
+
+  if (!crownOfEmphidia || !crownOfEmphidia.owner) {
+    return null;
+  }
+
+  let canScoreCrown = false;
+  for (const planet of Object.values(planets)) {
+    if (
+      planet.owner === crownOfEmphidia.owner &&
+      planet.attachments?.includes("Tomb of Emphidia")
+    ) {
+      canScoreCrown = true;
+      break;
+    }
+  }
+
+  if (!canScoreCrown) {
+    return null;
+  }
+
+  const wasPlayedThisTurn = getPlayedRelic(actionLog, "The Crown of Emphidia");
+  const isPurged = crownOfEmphidia.state === "purged";
+
+  if (isPurged && !wasPlayedThisTurn) {
+    return null;
+  }
+
+  return (
+    <LabeledDiv
+      label={getFactionName(factions[crownOfEmphidia.owner])}
+      color={getFactionColor(factions[crownOfEmphidia.owner])}
+    >
+      <div className="flexRow">
+        <FormattedMessage
+          id="/lAAq/"
+          defaultMessage="Score Crown of Emphidia?"
+          description="Message asking if a specific player scored the Crown of Emphidia relic."
+        />
+        <div
+          className="flexRow hiddenButtonParent"
+          style={{
+            position: "relative",
+            width: "32px",
+            height: "32px",
+          }}
+        >
+          <FactionIcon factionId={crownOfEmphidia.owner} size="100%" />
+          <div
+            className="flexRow"
+            style={{
+              position: "absolute",
+              backgroundColor: "#222",
+              cursor: "pointer",
+              borderRadius: "100%",
+              marginLeft: "60%",
+              marginTop: "60%",
+              boxShadow: `${"1px"} ${"1px"} ${"4px"} black`,
+              width: "20px",
+              height: "20px",
+              zIndex: 2,
+              color: wasPlayedThisTurn ? "green" : "red",
+            }}
+            onClick={() => {
+              if (!gameId) {
+                return;
+              }
+              if (wasPlayedThisTurn) {
+                unplayRelicAsync(gameId, {
+                  relic: "The Crown of Emphidia",
+                });
+              } else {
+                playRelicAsync(gameId, {
+                  relic: "The Crown of Emphidia",
+                });
+              }
+            }}
+          >
+            {wasPlayedThisTurn ? (
+              <div
+                className="symbol"
+                style={{
+                  fontSize: "18px",
+                  lineHeight: "18px",
+                }}
+              >
+                ✓
+              </div>
+            ) : (
+              <div
+                className="flexRow"
+                style={{
+                  width: "80%",
+                  height: "80%",
+                }}
+              >
+                <SymbolX color="red" />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </LabeledDiv>
+  );
+}

--- a/src/components/LogEntry.tsx
+++ b/src/components/LogEntry.tsx
@@ -4,6 +4,7 @@ import {
   AgendaContext,
   FactionContext,
   ObjectiveContext,
+  RelicContext,
   TechContext,
 } from "../context/Context";
 import { BLACK_TEXT_GLOW } from "../util/borderGlow";
@@ -50,6 +51,7 @@ export function LogEntryElement({
   const agendas = useContext(AgendaContext);
   const factions = useContext(FactionContext);
   const objectives = useContext(ObjectiveContext);
+  const relics = useContext(RelicContext);
   const techs = useContext(TechContext);
 
   switch (logEntry.data.action) {
@@ -183,6 +185,31 @@ export function LogEntryElement({
     case "PLAY_COMPONENT": {
       // TODO: Add different text for different components.
       return null;
+    }
+    case "SELECT_SUB_COMPONENT":
+      return (
+        <div
+          style={{
+            padding: `0 ${"10px"}`,
+            gap: "4px",
+            fontFamily: "Myriad Pro",
+          }}
+        >
+          Used Ssruu as {logEntry.data.event.subComponent}
+        </div>
+      );
+    case "SELECT_FACTION": {
+      return (
+        <div
+          style={{
+            padding: `0 ${"10px"}`,
+            gap: "4px",
+            fontFamily: "Myriad Pro",
+          }}
+        >
+          Used Z'eu Ω on {logEntry.data.event.faction}
+        </div>
+      );
     }
     case "MARK_SECONDARY": {
       // TODO: Display for all but Technology
@@ -524,6 +551,56 @@ export function LogEntryElement({
     }
     case "PLAY_ACTION_CARD": {
       return null;
+    }
+    case "PLAY_RELIC": {
+      console.log("Relic" + logEntry.data.event);
+      const relicOwner = relics[logEntry.data.event.relic]?.owner;
+      if (!relicOwner) {
+        return null;
+      }
+      switch (logEntry.data.event.relic) {
+        case "Maw of Worlds": {
+          const tech = techs[logEntry.data.event.tech];
+          if (!tech) {
+            return null;
+          }
+          return (
+            <div
+              className="flexRow"
+              style={{
+                padding: `0 ${"10px"}`,
+                gap: "4px",
+                fontFamily: "Myriad Pro",
+              }}
+            >
+              <ColoredFactionName factionId={relicOwner} />
+              purged Maw of Worlds to gain
+              <span style={{ color: getTechColor(tech) }}>
+                {logEntry.data.event.tech}
+              </span>
+            </div>
+          );
+        }
+        case "The Crown of Emphidia": {
+          const objective = objectives["Tomb + Crown of Emphidia"];
+          if (!objective) {
+            return null;
+          }
+          return (
+            <div
+              className="flexRow"
+              style={{
+                padding: `0 ${"10px"}`,
+                gap: "4px",
+                fontFamily: "Myriad Pro",
+              }}
+            >
+              <ColoredFactionName factionId={relicOwner} />
+              scored <ObjectiveRow objective={objective} hideScorers />
+            </div>
+          );
+        }
+      }
     }
     case "HIDE_AGENDA": {
       return (

--- a/src/components/MawOfWorlds/MawOfWorlds.tsx
+++ b/src/components/MawOfWorlds/MawOfWorlds.tsx
@@ -1,0 +1,114 @@
+import { useContext } from "react";
+import {
+  ActionLogContext,
+  FactionContext,
+  GameIdContext,
+  RelicContext,
+  TechContext,
+} from "../../context/Context";
+import LabeledDiv from "../LabeledDiv/LabeledDiv";
+import { getFactionColor, getFactionName } from "../../util/factions";
+import TechSelectHoverMenu from "../TechSelectHoverMenu/TechSelectHoverMenu";
+import { FormattedMessage, useIntl } from "react-intl";
+import { playRelicAsync, unplayRelicAsync } from "../../dynamic/api";
+import { hasTech } from "../../util/api/techs";
+import { getPlayedRelic } from "../../util/actionLog";
+import { TechRow } from "../../TechRow";
+import FactionIcon from "../FactionIcon/FactionIcon";
+
+export default function MawOfWorlds({}) {
+  const intl = useIntl();
+  const actionLog = useContext(ActionLogContext);
+  const factions = useContext(FactionContext);
+  const gameId = useContext(GameIdContext);
+  const relics = useContext(RelicContext);
+  const techs = useContext(TechContext);
+
+  const maw = relics["Maw of Worlds"];
+
+  if (!maw || !maw.owner) {
+    return null;
+  }
+
+  const owner = factions[maw.owner];
+
+  if (!owner) {
+    return null;
+  }
+
+  const mawEvent: MawOfWorldsEvent | undefined = getPlayedRelic(
+    actionLog,
+    "Maw of Worlds"
+  ) as MawOfWorldsEvent | undefined;
+
+  if (mawEvent) {
+    const tech = techs[mawEvent.tech];
+    if (!tech) {
+      return null;
+    }
+
+    return (
+      <LabeledDiv
+        label={
+          <div className="flexRow">
+            <FormattedMessage
+              id="Relics.Maw of Worlds.Title"
+              defaultMessage="Maw of Worlds"
+              description="Title of Relic: Maw of Worlds"
+            />
+
+            <FactionIcon factionId={owner.id} size={16} />
+          </div>
+        }
+        color={getFactionColor(owner)}
+        noBlur
+        style={{ fontSize: "14px" }}
+      >
+        <TechRow
+          tech={tech}
+          removeTech={(techId) => {
+            unplayRelicAsync(gameId, {
+              relic: "Maw of Worlds",
+              tech: techId,
+            });
+          }}
+        />
+      </LabeledDiv>
+    );
+  }
+
+  const isPurged = maw.state === "purged";
+  if (isPurged) {
+    return null;
+  }
+
+  const availableTechs = Object.values(techs).filter((tech) => {
+    const canResearch = !tech.faction || tech.faction === owner.id;
+    return canResearch && !hasTech(owner, tech.id);
+  });
+
+  return (
+    <LabeledDiv
+      label={getFactionName(owner)}
+      color={getFactionColor(owner)}
+      noBlur
+    >
+      <TechSelectHoverMenu
+        factionId={maw.owner}
+        ignorePrereqs
+        label={intl.formatMessage({
+          id: "Relics.Maw of Worlds.Title",
+          defaultMessage: "Maw of Worlds",
+          description: "Title of Relic: Maw of Worlds",
+        })}
+        selectTech={(tech) => {
+          playRelicAsync(gameId, {
+            relic: "Maw of Worlds",
+            tech: tech.id,
+          });
+        }}
+        techs={availableTechs}
+      />
+    </LabeledDiv>
+  );
+}

--- a/src/components/VoteBlock/VoteBlock.tsx
+++ b/src/components/VoteBlock/VoteBlock.tsx
@@ -8,6 +8,7 @@ import {
   ObjectiveContext,
   OptionContext,
   PlanetContext,
+  RelicContext,
   StateContext,
   StrategyCardContext,
 } from "../../context/Context";
@@ -26,6 +27,7 @@ import {
   getPlayedRiders,
   getAllVotes,
   getFactionVotes,
+  getPlayedRelic,
 } from "../../util/actionLog";
 import {
   getCurrentPhasePreviousLogEntries,
@@ -756,6 +758,7 @@ function VotingSection({
   const objectives = useContext(ObjectiveContext);
   const options = useContext(OptionContext);
   const planets = useContext(PlanetContext);
+  const relics = useContext(RelicContext);
   const state = useContext(StateContext);
   const strategycards = useContext(StrategyCardContext);
 
@@ -799,7 +802,7 @@ function VotingSection({
   const hasVotableTarget =
     !!factionVotes?.target && factionVotes?.target !== "Abstain";
 
-  const { influence } = computeRemainingVotes(
+  let { influence } = computeRemainingVotes(
     factionId,
     factions,
     planets,
@@ -809,6 +812,17 @@ function VotingSection({
     state,
     getCurrentPhasePreviousLogEntries(actionLog ?? [])
   );
+
+  const mawOfWorlds = relics["Maw of Worlds"];
+  if (mawOfWorlds && mawOfWorlds.owner === factionId) {
+    const mawEvent: MawOfWorldsEvent | undefined = getPlayedRelic(
+      actionLog,
+      "Maw of Worlds"
+    ) as MawOfWorldsEvent | undefined;
+    if (mawEvent) {
+      influence = 0;
+    }
+  }
   let castExtraVotes = factionVotes?.extraVotes ?? 0;
   const usingPredictive = getActionCardTargets(
     currentTurn,
@@ -1020,9 +1034,10 @@ function AvailableVotes({ factionId }: { factionId: FactionId }) {
   const factions = useContext(FactionContext);
   const options = useContext(OptionContext);
   const planets = useContext(PlanetContext);
+  const relics = useContext(RelicContext);
   const state = useContext(StateContext);
 
-  const { influence, extraVotes } = computeRemainingVotes(
+  let { influence, extraVotes } = computeRemainingVotes(
     factionId,
     factions,
     planets,
@@ -1032,6 +1047,16 @@ function AvailableVotes({ factionId }: { factionId: FactionId }) {
     state,
     getCurrentPhasePreviousLogEntries(actionLog)
   );
+  const mawOfWorlds = relics["Maw of Worlds"];
+  if (mawOfWorlds && mawOfWorlds.owner === factionId) {
+    const mawEvent: MawOfWorldsEvent | undefined = getPlayedRelic(
+      actionLog,
+      "Maw of Worlds"
+    ) as MawOfWorldsEvent | undefined;
+    if (mawEvent) {
+      influence = 0;
+    }
+  }
 
   const availableVotesStyle: AvailableVotesStyle = {
     "--height": "35px",

--- a/src/dynamic/api.ts
+++ b/src/dynamic/api.ts
@@ -58,6 +58,9 @@ const playComponentFn = import("../util/api/playComponent").then(
 const playPromissoryNoteFn = import("../util/api/playPromissoryNote").then(
   (mod) => mod.playPromissoryNote
 );
+const playRelicFn = import("../util/api/playRelic").then(
+  (mod) => mod.playRelic
+);
 const playRiderFn = import("../util/api/playRider").then(
   (mod) => mod.playRider
 );
@@ -130,6 +133,9 @@ const unplayComponentFn = import("../util/api/playComponent").then(
 );
 const unplayPromissoryNoteFn = import("../util/api/playPromissoryNote").then(
   (mod) => mod.unplayPromissoryNote
+);
+const unplayRelicFn = import("../util/api/playRelic").then(
+  (mod) => mod.unplayRelic
 );
 const unplayRiderFn = import("../util/api/playRider").then(
   (mod) => mod.unplayRider
@@ -329,6 +335,11 @@ export async function playPromissoryNoteAsync(
   playPromissoryNote(gameId, card, target);
 }
 
+export async function playRelicAsync(gameId: string, event: PlayRelicEvent) {
+  const playRelic = await playRelicFn;
+  playRelic(gameId, event);
+}
+
 export async function playRiderAsync(
   gameId: string,
   rider: string,
@@ -518,6 +529,11 @@ export async function unplayPromissoryNoteAsync(
 ) {
   const unplayPromissoryNote = await unplayPromissoryNoteFn;
   unplayPromissoryNote(gameId, card, target);
+}
+
+export async function unplayRelicAsync(gameId: string, event: PlayRelicEvent) {
+  const unplayRelic = await unplayRelicFn;
+  unplayRelic(gameId, event);
 }
 
 export async function unplayRiderAsync(gameId: string, rider: string) {

--- a/src/main/AgendaPhase.tsx
+++ b/src/main/AgendaPhase.tsx
@@ -74,6 +74,7 @@ import {
 } from "../util/strings";
 import styles from "./AgendaPhase.module.scss";
 import { Selector } from "../components/Selector/Selector";
+import MawOfWorlds from "../components/MawOfWorlds/MawOfWorlds";
 
 export function computeVotes(
   agenda: Agenda | undefined,
@@ -836,6 +837,7 @@ function AgendaSteps() {
                   }}
                   selectedItem={ancientBurialSites}
                 />
+                <MawOfWorlds />
               </div>
             </ClientOnlyHoverMenu>
           ) : null}

--- a/src/util/actionLog.ts
+++ b/src/util/actionLog.ts
@@ -212,3 +212,13 @@ export function getSpeakerTieBreak(actionLog: ActionLogEntry[]) {
       (logEntry) => (logEntry.data as SpeakerTieBreakData).event.tieBreak
     )[0];
 }
+
+export function getPlayedRelic(actionLog: ActionLogEntry[], relic: RelicId) {
+  return actionLog
+    .filter(
+      (logEntry) =>
+        logEntry.data.action === "PLAY_RELIC" &&
+        logEntry.data.event.relic === relic
+    )
+    .map((logEntry) => (logEntry.data as PlayRelicData).event)[0];
+}

--- a/src/util/api/gameLog.ts
+++ b/src/util/api/gameLog.ts
@@ -33,6 +33,7 @@ import {
   PlayPromissoryNoteHandler,
   UnplayPromissoryNoteHandler,
 } from "../model/playPromissoryNote";
+import { PlayRelicHandler } from "../model/playRelic";
 import { PlayRiderHandler, UnplayRiderHandler } from "../model/playRider";
 import {
   RepealAgendaHandler,
@@ -109,6 +110,8 @@ export function getHandler(gameData: StoredGameData, data: GameUpdateData) {
       return new PlayComponentHandler(gameData, data);
     case "PLAY_PROMISSORY_NOTE":
       return new PlayPromissoryNoteHandler(gameData, data);
+    case "PLAY_RELIC":
+      return new PlayRelicHandler(gameData, data);
     case "PLAY_RIDER":
       return new PlayRiderHandler(gameData, data);
     case "REMOVE_ATTACHMENT":

--- a/src/util/api/opposite.ts
+++ b/src/util/api/opposite.ts
@@ -18,6 +18,7 @@ import { MarkSecondaryHandler } from "../model/markSecondary";
 import { UnplayActionCardHandler } from "../model/playActionCard";
 import { UnplayComponentHandler } from "../model/playComponent";
 import { UnplayPromissoryNoteHandler } from "../model/playPromissoryNote";
+import { UnplayRelicHandler } from "../model/playRelic";
 import { UnplayRiderHandler } from "../model/playRider";
 import {
   RepealAgendaHandler,
@@ -417,6 +418,15 @@ export function getOppositeHandler(
     }
     case "START_VOTING": {
       return new UnstartVotingHandler(gameData, data);
+    }
+    case "PLAY_RELIC": {
+      return new UnplayRelicHandler(gameData, {
+        action: "UNPLAY_RELIC",
+        event: data.event,
+      });
+    }
+    case "UNPLAY_RELIC": {
+      throw new Error("UNPLAY_RELIC should not be in log");
     }
   }
 }

--- a/src/util/api/playRelic.ts
+++ b/src/util/api/playRelic.ts
@@ -1,0 +1,70 @@
+import { mutate } from "swr";
+import { BASE_GAME_DATA } from "../../../server/data/data";
+import { PlayRelicHandler, UnplayRelicHandler } from "../model/playRelic";
+import { updateGameData } from "./handler";
+import { updateActionLog } from "./update";
+import { poster } from "./util";
+
+export function playRelic(gameId: string, event: PlayRelicEvent) {
+  const data: GameUpdateData = {
+    action: "PLAY_RELIC",
+    event,
+  };
+
+  mutate(
+    `/api/${gameId}/data`,
+    async () => await poster(`/api/${gameId}/dataUpdate`, data),
+    {
+      optimisticData: (currentData?: StoredGameData) => {
+        if (!currentData) {
+          return BASE_GAME_DATA;
+        }
+        const handler = new PlayRelicHandler(currentData, data);
+
+        if (!handler.validate()) {
+          return currentData;
+        }
+
+        const updates = handler.getUpdates();
+
+        updateActionLog(currentData, handler);
+
+        updateGameData(currentData, updates);
+
+        return structuredClone(currentData);
+      },
+      revalidate: false,
+    }
+  );
+}
+
+export function unplayRelic(gameId: string, event: PlayRelicEvent) {
+  const data: GameUpdateData = {
+    action: "UNPLAY_RELIC",
+    event,
+  };
+
+  mutate(
+    `/api/${gameId}/data`,
+    async () => await poster(`/api/${gameId}/dataUpdate`, data),
+    {
+      optimisticData: (currentData?: StoredGameData) => {
+        if (!currentData) {
+          return BASE_GAME_DATA;
+        }
+        const handler = new UnplayRelicHandler(currentData, data);
+
+        if (!handler.validate()) {
+          return currentData;
+        }
+
+        updateGameData(currentData, handler.getUpdates());
+
+        updateActionLog(currentData, handler);
+
+        return structuredClone(currentData);
+      },
+      revalidate: false,
+    }
+  );
+}

--- a/src/util/model/playRelic.ts
+++ b/src/util/model/playRelic.ts
@@ -1,6 +1,10 @@
 import { createIntl, createIntlCache } from "react-intl";
 import { buildRelics } from "../../data/GameData";
 import { AddTechHandler, RemoveTechHandler } from "./addTech";
+import {
+  ScoreObjectiveHandler,
+  UnscoreObjectiveHandler,
+} from "./scoreObjective";
 
 export class PlayRelicHandler implements Handler {
   constructor(public gameData: StoredGameData, public data: PlayRelicData) {}
@@ -27,18 +31,35 @@ export class PlayRelicHandler implements Handler {
       [`relics.${this.data.event.relic}.state`]: "purged",
     };
 
-    if (this.data.event.relic === "Maw of Worlds") {
-      const gainTechHandler = new AddTechHandler(this.gameData, {
-        action: "ADD_TECH",
-        event: {
-          faction: relic.owner,
-          tech: this.data.event.tech,
-        },
-      });
-      updates = {
-        ...updates,
-        ...gainTechHandler.getUpdates(),
-      };
+    switch (this.data.event.relic) {
+      case "Maw of Worlds": {
+        const gainTechHandler = new AddTechHandler(this.gameData, {
+          action: "ADD_TECH",
+          event: {
+            faction: relic.owner,
+            tech: this.data.event.tech,
+          },
+        });
+        updates = {
+          ...updates,
+          ...gainTechHandler.getUpdates(),
+        };
+        break;
+      }
+      case "The Crown of Emphidia": {
+        const scoreObjectiveHandler = new ScoreObjectiveHandler(this.gameData, {
+          action: "SCORE_OBJECTIVE",
+          event: {
+            faction: relic.owner,
+            objective: "Tomb + Crown of Emphidia",
+          },
+        });
+        updates = {
+          ...updates,
+          ...scoreObjectiveHandler.getUpdates(),
+        };
+        break;
+      }
     }
 
     return updates;
@@ -88,18 +109,38 @@ export class UnplayRelicHandler implements Handler {
       [`relics.${this.data.event.relic}.state`]: "DELETE",
     };
 
-    if (this.data.event.relic === "Maw of Worlds") {
-      const removeTechHandler = new RemoveTechHandler(this.gameData, {
-        action: "REMOVE_TECH",
-        event: {
-          faction: relic.owner,
-          tech: this.data.event.tech,
-        },
-      });
-      updates = {
-        ...updates,
-        ...removeTechHandler.getUpdates(),
-      };
+    switch (this.data.event.relic) {
+      case "Maw of Worlds": {
+        const removeTechHandler = new RemoveTechHandler(this.gameData, {
+          action: "REMOVE_TECH",
+          event: {
+            faction: relic.owner,
+            tech: this.data.event.tech,
+          },
+        });
+        updates = {
+          ...updates,
+          ...removeTechHandler.getUpdates(),
+        };
+        break;
+      }
+      case "The Crown of Emphidia": {
+        const unscoreObjectiveHandler = new UnscoreObjectiveHandler(
+          this.gameData,
+          {
+            action: "UNSCORE_OBJECTIVE",
+            event: {
+              faction: relic.owner,
+              objective: "Tomb + Crown of Emphidia",
+            },
+          }
+        );
+        updates = {
+          ...updates,
+          ...unscoreObjectiveHandler.getUpdates(),
+        };
+        break;
+      }
     }
 
     return updates;

--- a/src/util/model/playRelic.ts
+++ b/src/util/model/playRelic.ts
@@ -1,0 +1,125 @@
+import { createIntl, createIntlCache } from "react-intl";
+import { buildRelics } from "../../data/GameData";
+import { AddTechHandler, RemoveTechHandler } from "./addTech";
+
+export class PlayRelicHandler implements Handler {
+  constructor(public gameData: StoredGameData, public data: PlayRelicData) {}
+
+  validate(): boolean {
+    return true;
+  }
+
+  getUpdates(): Record<string, any> {
+    const cache = createIntlCache();
+    const intl = createIntl({ locale: "en" }, cache);
+    const relic = buildRelics(this.gameData, intl)[this.data.event.relic];
+
+    if (!relic) {
+      return {};
+    }
+
+    if (!relic.owner) {
+      return {};
+    }
+
+    let updates: Record<string, any> = {
+      [`state.paused`]: false,
+      [`relics.${this.data.event.relic}.state`]: "purged",
+    };
+
+    if (this.data.event.relic === "Maw of Worlds") {
+      const gainTechHandler = new AddTechHandler(this.gameData, {
+        action: "ADD_TECH",
+        event: {
+          faction: relic.owner,
+          tech: this.data.event.tech,
+        },
+      });
+      updates = {
+        ...updates,
+        ...gainTechHandler.getUpdates(),
+      };
+    }
+
+    return updates;
+  }
+
+  getLogEntry(): ActionLogEntry {
+    return {
+      timestampMillis: Date.now(),
+      data: this.data,
+    };
+  }
+
+  getActionLogAction(entry: ActionLogEntry): ActionLogAction {
+    if (
+      entry.data.action === "UNPLAY_RELIC" &&
+      entry.data.event.relic === this.data.event.relic
+    ) {
+      return "DELETE";
+    }
+
+    return "IGNORE";
+  }
+}
+
+export class UnplayRelicHandler implements Handler {
+  constructor(public gameData: StoredGameData, public data: UnplayRelicData) {}
+
+  validate(): boolean {
+    return true;
+  }
+
+  getUpdates(): Record<string, any> {
+    const cache = createIntlCache();
+    const intl = createIntl({ locale: "en" }, cache);
+    const relic = buildRelics(this.gameData, intl)[this.data.event.relic];
+
+    if (!relic) {
+      return {};
+    }
+
+    if (!relic.owner) {
+      return {};
+    }
+
+    let updates: Record<string, any> = {
+      [`state.paused`]: false,
+      [`relics.${this.data.event.relic}.state`]: "DELETE",
+    };
+
+    if (this.data.event.relic === "Maw of Worlds") {
+      const removeTechHandler = new RemoveTechHandler(this.gameData, {
+        action: "REMOVE_TECH",
+        event: {
+          faction: relic.owner,
+          tech: this.data.event.tech,
+        },
+      });
+      updates = {
+        ...updates,
+        ...removeTechHandler.getUpdates(),
+      };
+    }
+
+    return updates;
+  }
+
+  getLogEntry(): ActionLogEntry {
+    return {
+      timestampMillis: Date.now(),
+      data: this.data,
+    };
+  }
+
+  getActionLogAction(entry: ActionLogEntry): ActionLogAction {
+    if (
+      entry.data.action === "PLAY_RELIC" &&
+      entry.data.event.relic === this.data.event.relic
+    ) {
+      return "DELETE";
+    }
+
+    return "IGNORE";
+  }
+}

--- a/src/util/types/api.d.ts
+++ b/src/util/types/api.d.ts
@@ -569,7 +569,7 @@ interface StartVotingData {
 type PlayRelicEvent =
   | MawOfWorldsEvent
   | {
-      relic: Exclude<"Maw of Worlds", RelicId>;
+      relic: Exclude<RelicId, "Maw of Worlds">;
     };
 
 interface MawOfWorldsEvent {

--- a/src/util/types/api.d.ts
+++ b/src/util/types/api.d.ts
@@ -49,6 +49,7 @@ type GameUpdateData =
   | SetObjectivePointsData
   | SpeakerTieBreakData
   | StartVotingData
+  | (PlayRelicData | UnplayRelicData)
   // TODO
   | UndoData;
 
@@ -563,4 +564,25 @@ interface StartVotingEvent {}
 interface StartVotingData {
   action: "START_VOTING";
   event: StartVotingEvent;
+}
+
+type PlayRelicEvent =
+  | MawOfWorldsEvent
+  | {
+      relic: Exclude<"Maw of Worlds", RelicId>;
+    };
+
+interface MawOfWorldsEvent {
+  relic: "Maw of Worlds";
+  tech: TechId;
+}
+
+interface PlayRelicData {
+  action: "PLAY_RELIC";
+  event: PlayRelicEvent;
+}
+
+interface UnplayRelicData {
+  action: "UNPLAY_RELIC";
+  event: PlayRelicEvent;
 }


### PR DESCRIPTION
### **Maw of Worlds**
* Now is able to be played at the start of Agenda Phase to gain a technology.
* If played, will set that player's votes to 0 for the duration of the phase.
* Once used, cannot be used again.

### **The Crown of Emphidia**
* Will now appear properly in the game log. 
* Once used, cannot be used again.