### PR TITLE
Add Muaat hero, better general hero support, and better options menu

### DIFF
--- a/app/api/[gameId]/dataUpdate/route.ts
+++ b/app/api/[gameId]/dataUpdate/route.ts
@@ -97,6 +97,10 @@ import {
   PlayRelicHandler,
   UnplayRelicHandler,
 } from "../../../../src/util/model/playRelic";
+import {
+  UndoAdjudicatorBaalHandler,
+  PlayAdjudicatorBaalHandler,
+} from "../../../../src/util/model/playAdjudicatorBaal";
 
 export async function POST(
   req: Request,
@@ -495,6 +499,12 @@ function updateInTransaction(
         handler = new UnplayRelicHandler(gameData, data);
         break;
       }
+      case "PLAY_ADJUDICATOR_BAAL":
+        handler = new PlayAdjudicatorBaalHandler(gameData, data);
+        break;
+      case "UNDO_ADJUDICATOR_BAAL":
+        handler = new UndoAdjudicatorBaalHandler(gameData, data);
+        break;
       case "UNDO": {
         const actionToUndo = (gameData.actionLog ?? [])[0];
 

--- a/app/setup/setup-page.tsx
+++ b/app/setup/setup-page.tsx
@@ -19,6 +19,7 @@ import { convertToFactionColor } from "../../src/util/factions";
 import { mapStyleString } from "../../src/util/strings";
 import styles from "./setup.module.scss";
 import Toggle from "../../src/components/Toggle/Toggle";
+import NumberInput from "../../src/components/NumberInput/NumberInput";
 
 const SetupFactionPanel = dynamic(
   () => import("../../src/components/SetupFactionPanel"),
@@ -151,87 +152,30 @@ function MobileOptions({
                 padding: `${"8px"} ${"16px"} 0 ${"16px"}`,
               }}
             >
-              <div className="flexColumn" style={{ alignItems: "flex-start" }}>
+              <div className="flexRow" style={{ alignItems: "flex-start" }}>
                 <FormattedMessage
                   id="R06tnh"
                   description="A label for a selector specifying the number of victory points required."
                   defaultMessage="Victory Points"
                 />
                 :
-                <div
-                  className="flexRow"
-                  style={{
-                    justifyContent: "flex-start",
-                    padding: `0 ${"20px"}`,
-                  }}
-                >
-                  <button
-                    className={
-                      options["victory-points"] === 10 ? "selected" : ""
-                    }
-                    onClick={() => {
-                      toggleOption(10, "victory-points");
-                    }}
-                  >
-                    10
-                  </button>
-                  <button
-                    className={
-                      options["victory-points"] === 14 ? "selected" : ""
-                    }
-                    onClick={() => {
-                      toggleOption(14, "victory-points");
-                    }}
-                  >
-                    14
-                  </button>
-                  <button
-                    className={
-                      options["victory-points"] !== 14 &&
-                      options["victory-points"] !== 10
-                        ? "selected"
-                        : ""
-                    }
-                    onClick={() => {
-                      toggleOption(
-                        parseInt(otherPointsRef.current?.innerText ?? "10"),
-                        "victory-points"
-                      );
-                    }}
-                  >
-                    <FormattedMessage
-                      id="sgqLYB"
-                      description="Text on a button used to select a non-listed value"
-                      defaultMessage="Other"
-                    />
-                  </button>
-                  <div
-                    ref={otherPointsRef}
-                    spellCheck={false}
-                    contentEditable={true}
-                    suppressContentEditableWarning={true}
-                    onClick={(e) => (e.currentTarget.innerText = "")}
-                    onBlur={(e) => {
-                      const victoryPoints = parseInt(e.target.innerText);
-                      if (isNaN(victoryPoints) || victoryPoints <= 0) {
-                        if (
-                          options["victory-points"] !== 10 &&
-                          options["victory-points"] !== 14
-                        ) {
-                          e.currentTarget.innerText =
-                            options["victory-points"].toString();
-                        } else {
-                          e.currentTarget.innerText = "12";
-                        }
-                      } else {
-                        toggleOption(victoryPoints, "victory-points");
-                        e.currentTarget.innerText = victoryPoints.toString();
+                <NumberInput
+                  value={options["victory-points"]}
+                  onChange={(newVal) => toggleOption(newVal, "victory-points")}
+                  minValue={0}
+                />
+                {options["game-variant"] === "alliance-separate" ? (
+                  <>
+                    &
+                    <NumberInput
+                      value={options["secondary-victory-points"]}
+                      onChange={(newVal) =>
+                        toggleOption(newVal, "secondary-victory-points")
                       }
-                    }}
-                  >
-                    12
-                  </div>
-                </div>
+                      minValue={0}
+                    />
+                  </>
+                ) : null}
               </div>
               <div className="flexColumn" style={{ alignItems: "flex-start" }}>
                 <FormattedMessage
@@ -247,69 +191,87 @@ function MobileOptions({
                     padding: `0 ${"20px"}`,
                   }}
                 >
-                  <button
-                    className={options.expansions.has("POK") ? "selected" : ""}
-                    onClick={() =>
-                      toggleExpansion(!options.expansions.has("POK"), "POK")
-                    }
+                  <Toggle
+                    selected={options.expansions.has("POK")}
+                    toggleFn={(prevValue) => {
+                      toggleExpansion(!prevValue, "POK");
+                    }}
                   >
                     <FormattedMessage
                       id="p9XVGB"
                       description="Text on a button that will enable/disable the Prophecy of Kings expansion."
                       defaultMessage="Prophecy of Kings"
                     />
-                  </button>
-                  <button
-                    className={
-                      options.expansions.has("CODEX ONE") ? "selected" : ""
-                    }
-                    onClick={() =>
-                      toggleExpansion(
-                        !options.expansions.has("CODEX ONE"),
-                        "CODEX ONE"
-                      )
-                    }
+                  </Toggle>
+                  <Toggle
+                    selected={options.expansions.has("CODEX ONE")}
+                    toggleFn={(prevValue) => {
+                      toggleExpansion(!prevValue, "CODEX ONE");
+                    }}
                   >
                     <FormattedMessage
                       id="3Taw9H"
                       description="Text on a button that will enable/disable Codex I."
                       defaultMessage="Codex I"
                     />
-                  </button>
-                  <button
-                    className={
-                      options.expansions.has("CODEX TWO") ? "selected" : ""
-                    }
-                    onClick={() =>
-                      toggleExpansion(
-                        !options.expansions.has("CODEX TWO"),
-                        "CODEX TWO"
-                      )
-                    }
+                  </Toggle>
+                  <Toggle
+                    selected={options.expansions.has("CODEX TWO")}
+                    toggleFn={(prevValue) => {
+                      toggleExpansion(!prevValue, "CODEX TWO");
+                    }}
                   >
                     <FormattedMessage
                       id="knYKVl"
                       description="Text on a button that will enable/disable Codex II."
                       defaultMessage="Codex II"
                     />
-                  </button>
-                  <button
-                    className={
-                      options.expansions.has("CODEX THREE") ? "selected" : ""
-                    }
-                    onClick={() =>
-                      toggleExpansion(
-                        !options.expansions.has("CODEX THREE"),
-                        "CODEX THREE"
-                      )
-                    }
+                  </Toggle>
+                  <Toggle
+                    selected={options.expansions.has("CODEX THREE")}
+                    toggleFn={(prevValue) => {
+                      toggleExpansion(!prevValue, "CODEX THREE");
+                    }}
                   >
                     <FormattedMessage
                       id="zXrdrP"
                       description="Text on a button that will enable/disable Codex III."
                       defaultMessage="Codex III"
                     />
-                  </button>
+                  </Toggle>
+                </div>
+                <div
+                  className="flexColumn mediumFont"
+                  style={{
+                    alignItems: "flex-start",
+                    padding: `0 ${"20px"}`,
+                  }}
+                >
+                  <FormattedMessage
+                    id="weIxIg"
+                    description="A label for a selector specifying expansions that are homemade."
+                    defaultMessage="Homebrew:"
+                  />
+                  <div
+                    className="flexRow"
+                    style={{
+                      justifyContent: "flex-start",
+                      padding: `0 ${"20px"}`,
+                    }}
+                  >
+                    <Toggle
+                      selected={options.expansions.has("DISCORDANT STARS")}
+                      toggleFn={(prevValue) => {
+                        toggleExpansion(!prevValue, "DISCORDANT STARS");
+                      }}
+                    >
+                      <FormattedMessage
+                        id="ZlvDZB"
+                        description="Text on a button that will enable/disable the Discordant Stars expansion."
+                        defaultMessage="Discordant Stars"
+                      />
+                    </Toggle>
+                  </div>
                 </div>
               </div>
               <div>
@@ -510,156 +472,34 @@ function Options({
               padding: `${"8px"} ${"16px"} 0 ${"16px"}`,
             }}
           >
-            <div className="flexColumn" style={{ alignItems: "flex-start" }}>
+            <div className="flexRow" style={{ alignItems: "flex-start" }}>
               <FormattedMessage
                 id="R06tnh"
                 description="A label for a selector specifying the number of victory points required."
                 defaultMessage="Victory Points"
               />
               :
-              <div
-                className="flexRow"
-                style={{
-                  justifyContent: "flex-start",
-                  padding: `0 ${"20px"}`,
-                }}
-              >
-                {defaultVPs.map((VPs, index) => {
-                  return (
-                    <button
-                      key={index}
-                      className={
-                        options["victory-points"] === VPs ? "selected" : ""
-                      }
-                      onClick={() => {
-                        toggleOption(VPs, "victory-points");
-                      }}
-                    >
-                      {VPs}
-                    </button>
-                  );
-                })}
-                <button
-                  className={
-                    !defaultVPs.includes(options["victory-points"])
-                      ? "selected"
-                      : ""
-                  }
-                  onClick={() => {
-                    toggleOption(
-                      parseInt(otherPointsRef.current?.innerText ?? "10"),
-                      "victory-points"
-                    );
-                  }}
-                >
+              <NumberInput
+                value={options["victory-points"]}
+                onChange={(newVal) => toggleOption(newVal, "victory-points")}
+                minValue={0}
+              />
+              {options["game-variant"] === "alliance-separate" ? (
+                <>
                   <FormattedMessage
-                    id="sgqLYB"
-                    description="Text on a button used to select a non-listed value"
-                    defaultMessage="Other"
+                    id="+WkrHz"
+                    description="Text between two fields linking them together."
+                    defaultMessage="AND"
                   />
-                </button>
-                <div
-                  ref={otherPointsRef}
-                  spellCheck={false}
-                  contentEditable={true}
-                  suppressContentEditableWarning={true}
-                  onClick={(e) => (e.currentTarget.innerText = "")}
-                  onBlur={(e) => {
-                    const victoryPoints = parseInt(e.target.innerText);
-                    if (isNaN(victoryPoints) || victoryPoints <= 0) {
-                      if (defaultVPs.includes(options["victory-points"])) {
-                        e.currentTarget.innerText =
-                          options["victory-points"].toString();
-                      } else {
-                        e.currentTarget.innerText = otherDefault.toString();
-                      }
-                    } else {
-                      toggleOption(victoryPoints, "victory-points");
-                      e.currentTarget.innerText = victoryPoints.toString();
+                  <NumberInput
+                    value={options["secondary-victory-points"]}
+                    onChange={(newVal) =>
+                      toggleOption(newVal, "secondary-victory-points")
                     }
-                  }}
-                >
-                  {otherDefault}
-                </div>
-                {options["game-variant"] === "alliance-separate" ? (
-                  <>
-                    <div>
-                      <FormattedMessage
-                        id="+WkrHz"
-                        description="Text between two fields linking them together."
-                        defaultMessage="AND"
-                      />
-                    </div>
-                    {defaultVPs.map((VPs, index) => {
-                      return (
-                        <button
-                          key={index}
-                          className={
-                            options["secondary-victory-points"] === VPs
-                              ? "selected"
-                              : ""
-                          }
-                          onClick={() => {
-                            toggleOption(VPs, "secondary-victory-points");
-                          }}
-                        >
-                          {VPs}
-                        </button>
-                      );
-                    })}
-                    <button
-                      className={
-                        options["secondary-victory-points"] !== 14 &&
-                        options["secondary-victory-points"] !== 10
-                          ? "selected"
-                          : ""
-                      }
-                      onClick={() => {
-                        toggleOption(
-                          parseInt(otherPointsRef.current?.innerText ?? "10"),
-                          "secondary-victory-points"
-                        );
-                      }}
-                    >
-                      <FormattedMessage
-                        id="sgqLYB"
-                        description="Text on a button used to select a non-listed value"
-                        defaultMessage="Other"
-                      />
-                    </button>
-                    <div
-                      ref={otherPointsRef}
-                      spellCheck={false}
-                      contentEditable={true}
-                      suppressContentEditableWarning={true}
-                      onClick={(e) => (e.currentTarget.innerText = "")}
-                      onBlur={(e) => {
-                        const victoryPoints = parseInt(e.target.innerText);
-                        if (isNaN(victoryPoints) || victoryPoints <= 0) {
-                          if (
-                            defaultVPs.includes(
-                              options["secondary-victory-points"]
-                            )
-                          ) {
-                            e.currentTarget.innerText =
-                              options["secondary-victory-points"].toString();
-                          } else {
-                            e.currentTarget.innerText = otherDefault.toString();
-                          }
-                        } else {
-                          toggleOption(
-                            victoryPoints,
-                            "secondary-victory-points"
-                          );
-                          e.currentTarget.innerText = victoryPoints.toString();
-                        }
-                      }}
-                    >
-                      {otherDefault}
-                    </div>
-                  </>
-                ) : null}
-              </div>
+                    minValue={0}
+                  />
+                </>
+              ) : null}
             </div>
             <div className="flexColumn" style={{ alignItems: "flex-start" }}>
               <FormattedMessage
@@ -671,7 +511,7 @@ function Options({
                 className="flexRow"
                 style={{
                   justifyContent: "flex-start",
-                  padding: `0 ${"20px"}`,
+                  padding: `0 16px`,
                 }}
               >
                 <Toggle
@@ -727,7 +567,7 @@ function Options({
                 className="flexColumn mediumFont"
                 style={{
                   alignItems: "flex-start",
-                  padding: `0 ${"20px"}`,
+                  padding: `0 16px`,
                 }}
               >
                 <FormattedMessage
@@ -739,7 +579,7 @@ function Options({
                   className="flexRow"
                   style={{
                     justifyContent: "flex-start",
-                    padding: `0 ${"20px"}`,
+                    padding: `0 16px`,
                   }}
                 >
                   <Toggle

--- a/server/compiled-lang/en.json
+++ b/server/compiled-lang/en.json
@@ -10847,6 +10847,16 @@
       "value": "Re-shuffle secret objectives"
     }
   ],
+  "dsGVrU": [
+    {
+      "type": 0,
+      "value": "Replaced System "
+    },
+    {
+      "type": 1,
+      "value": "system"
+    }
+  ],
   "e01Ge2": [
     {
       "type": 0,

--- a/server/lang/en.json
+++ b/server/lang/en.json
@@ -5715,6 +5715,10 @@
     "defaultMessage": "Re-shuffle secret objectives",
     "description": "A step in the setup phase: Re-shuffle secret objectives."
   },
+  "dsGVrU": {
+    "defaultMessage": "Replaced System {system}",
+    "description": "Message telling a player which system was replaced by the Muaat hero"
+  },
   "e01Ge2": {
     "defaultMessage": "Tactical Action",
     "description": "Type of action involving activating a system."

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -75,8 +75,13 @@ export default function Header() {
   );
   let mallice;
   if (options && (options["expansions"] ?? []).includes("POK")) {
-    mallice = "A";
-    if (planets && (planets["Mallice"] ?? {}).owner) {
+    const malliceObj = planets["Mallice"];
+    if (!malliceObj) {
+      mallice = "PURGED";
+    } else {
+      mallice = "A";
+    }
+    if ((planets["Mallice"] ?? {}).owner) {
       mallice = "B";
     }
   }

--- a/src/components/LogEntry.tsx
+++ b/src/components/LogEntry.tsx
@@ -553,7 +553,6 @@ export function LogEntryElement({
       return null;
     }
     case "PLAY_RELIC": {
-      console.log("Relic" + logEntry.data.event);
       const relicOwner = relics[logEntry.data.event.relic]?.owner;
       if (!relicOwner) {
         return null;

--- a/src/components/LogEntry.tsx
+++ b/src/components/LogEntry.tsx
@@ -601,6 +601,21 @@ export function LogEntryElement({
         }
       }
     }
+    case "PLAY_ADJUDICATOR_BAAL": {
+      return (
+        <div
+          className="flexRow"
+          style={{
+            padding: `0 ${"10px"}`,
+            gap: "4px",
+            fontFamily: "Myriad Pro",
+          }}
+        >
+          <ColoredFactionName factionId="Embers of Muaat" />
+          used Adjudicator Ba'al to replace system {logEntry.data.event.systemId} with Muaat supernova.
+        </div>
+      );
+    }
     case "HIDE_AGENDA": {
       return (
         <div

--- a/src/components/Map/Map.module.scss
+++ b/src/components/Map/Map.module.scss
@@ -33,6 +33,13 @@
   pointer-events: none;
 }
 
+.SystemSelectBody {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
 .Legend {
   position: absolute;
   margin-left: -120%;

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -979,7 +979,7 @@ export default function Map({
             <SystemImage
               gameId={gameId}
               showDetails={showDetails}
-              systemNumber={`82${mallice}`}
+              systemNumber={mallice === "PURGED" ? "81" : `82${mallice}`}
             />
           </div>
         ) : null}

--- a/src/components/Map/SystemSelect.tsx
+++ b/src/components/Map/SystemSelect.tsx
@@ -1,0 +1,573 @@
+import NextImage from "next/image";
+import { useContext } from "react";
+import Hexagon from "../../../public/images/systems/Hexagon.png";
+import { GameIdContext } from "../../context/Context";
+import { updateMapString, validSystemNumber } from "../../util/map";
+import styles from "./Map.module.scss";
+
+interface Cube {
+  q: number;
+  r: number;
+  s: number;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+function Cube(q: number, r: number, s: number): Cube {
+  return {
+    q,
+    r,
+    s,
+  };
+}
+
+function Point(x: number, y: number): Point {
+  return {
+    x,
+    y,
+  };
+}
+
+const HEX_RATIO = 2 / Math.sqrt(3);
+
+const CUBE_DIRECTIONS = [
+  Cube(0, -1, +1),
+  Cube(+1, -1, 0),
+  Cube(+1, 0, -1),
+  Cube(0, +1, -1),
+  Cube(-1, +1, 0),
+  Cube(-1, 0, +1),
+] as const;
+
+function cube_add(hex: Cube, vec: Cube) {
+  return Cube(hex.q + vec.q, hex.r + vec.r, hex.s + vec.s);
+}
+
+function cube_neighbor(cube: Cube, direction: Cube) {
+  return cube_add(cube, direction);
+}
+
+function cube_scale(hex: Cube, factor: number) {
+  return Cube(hex.q * factor, hex.r * factor, hex.s * factor);
+}
+
+function cubeRing(center: Cube, radius: number) {
+  const results: Cube[] = [];
+  let hex = cube_add(center, cube_scale(CUBE_DIRECTIONS[4], radius));
+  for (const direction of CUBE_DIRECTIONS) {
+    for (let j = 0; j < radius; j++) {
+      results.push(hex);
+      hex = cube_neighbor(hex, direction);
+    }
+  }
+  return results;
+}
+
+function cubeSpiral(center: Cube, radius: number) {
+  let results: Cube[] = [center];
+  for (let i = 1; i < radius; i++) {
+    results = results.concat(cubeRing(center, i));
+  }
+  return results;
+}
+
+function CubeToPixel(hex: Cube, size: number) {
+  const x = size * ((3 / 2) * hex.s);
+  const y = size * ((Math.sqrt(3) / 2) * hex.s + Math.sqrt(3) * hex.q);
+  return Point(x, y);
+}
+
+const FACTION_TO_SYSTEM_NUMBER: Record<FactionId, string> = {
+  "Council Keleres": "92",
+  "Federation of Sol": "1",
+  "Mentak Coalition": "2",
+  "Yin Brotherhood": "3",
+  "Embers of Muaat": "4",
+  Arborec: "5",
+  "L1Z1X Mindnet": "6",
+  Winnu: "7",
+  "Nekro Virus": "8",
+  "Naalu Collective": "9",
+  "Barony of Letnev": "10",
+  "Clan of Saar": "11",
+  "Universities of Jol-Nar": "12",
+  "Sardakk N'orr": "13",
+  "Xxcha Kingdom": "14",
+  "Yssaril Tribes": "15",
+  "Emirates of Hacan": "16",
+  "Ghosts of Creuss": "17",
+  "Mahact Gene-Sorcerers": "52",
+  Nomad: "53",
+  "Vuil'raith Cabal": "54",
+  "Titans of Ul": "55",
+  Empyrean: "56",
+  "Naaz-Rokha Alliance": "57",
+  "Argent Flight": "58",
+  "Augurs of Ilyxum": "1001",
+  "Bentor Conglomerate": "1002",
+  "Berserkers of Kjalengard": "1003",
+  "Celdauri Trade Confederation": "1004",
+  "Cheiran Hordes": "1005",
+  "Dih-Mohn Flotilla": "1006",
+  "Edyn Mandate": "1007",
+  "Florzen Profiteers": "1008",
+  "Free Systems Compact": "1009",
+  "Ghemina Raiders": "1010",
+  "Ghoti Wayfarers": "1011",
+  "Gledge Union": "1012",
+  "Glimmer of Mortheus": "1013",
+  "Kollecc Society": "1014",
+  "Kortali Tribunal": "1015",
+  "Kyro Sodality": "1016",
+  "Lanefir Remnants": "1017",
+  "Li-Zho Dynasty": "1018",
+  "L'tokk Khrask": "1019",
+  "Mirveda Protectorate": "1020",
+  "Monks of Kolume": "1021",
+  "Myko-Mentori": "1022",
+  "Nivyn Star Kings": "1023",
+  "Nokar Sellships": "1024",
+  "Olradin League": "1025",
+  "Roh'Dhna Mechatronics": "1026",
+  "Savages of Cymiae": "1027",
+  "Shipwrights of Axis": "1028",
+  "Tnelis Syndicate": "1029",
+  "Vaden Banking Clans": "1030",
+  "Vaylerian Scourge": "1031",
+  "Veldyr Sovereignty": "1032",
+  "Zealots of Rhodun": "1033",
+  "Zelian Purifier": "1034",
+} as const;
+
+function getFactionSystemNumber(
+  faction:
+    | {
+        id?: FactionId;
+        name?: string;
+        startswith?: {
+          faction?: FactionId;
+        };
+      }
+    | undefined
+) {
+  if (!faction?.id) {
+    return "92";
+  }
+  if (faction.id === "Council Keleres") {
+    switch (faction.startswith?.faction) {
+      case "Argent Flight":
+        return "101";
+      case "Xxcha Kingdom":
+        return "100";
+      case "Mentak Coalition":
+        return "102";
+    }
+    return "92";
+  }
+  return FACTION_TO_SYSTEM_NUMBER[faction.id] ?? "92";
+}
+
+function getRotationClass(key: string) {
+  switch (key) {
+    case "rotateSixty":
+      return styles.rotateSixty;
+    case "rotateOneTwenty":
+      return styles.rotateOneTwenty;
+    case "rotateOneEighty":
+      return styles.rotateOneEighty;
+    case "rotateTwoForty":
+      return styles.rotateTwoForty;
+    case "rotateThreeHundred":
+      return styles.rotateThreeHundred;
+  }
+}
+
+function getRotationClassFromNumber(key: number) {
+  switch (key) {
+    case 1:
+      return styles.rotateSixty;
+    case 2:
+      return styles.rotateOneTwenty;
+    case 3:
+      return styles.rotateOneEighty;
+    case 4:
+      return styles.rotateTwoForty;
+    case 5:
+      return styles.rotateThreeHundred;
+  }
+  return "";
+}
+
+export function SystemImage({
+  gameId,
+  systemNumber,
+  selectable,
+  onClick,
+}: {
+  gameId: string;
+  systemNumber: string | undefined;
+  selectable: boolean;
+  onClick: (systemId: string) => void;
+}) {
+  if (
+    !systemNumber ||
+    systemNumber === "0" ||
+    !validSystemNumber(systemNumber)
+  ) {
+    if (systemNumber && systemNumber.split(":").length > 1) {
+      const classNames = getRotationClass(systemNumber.split(":")[0] ?? "");
+      systemNumber = systemNumber.split(":")[1] ?? "";
+      return (
+        <div
+          className={`flexRow ${classNames}`}
+          style={{
+            position: "relative",
+            width: "100%",
+            height: "100%",
+            cursor: selectable ? "pointer" : undefined,
+            opacity: selectable ? undefined : 0.25,
+          }}
+        >
+          <NextImage
+            src={`/images/systems/ST_${systemNumber}.png`}
+            alt={`System ${systemNumber} Tile`}
+            fill
+            style={{ objectFit: "contain" }}
+          />
+        </div>
+      );
+    }
+    return (
+      <div
+        className="flexRow"
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "100%",
+          cursor: selectable ? "pointer" : undefined,
+          opacity: selectable ? undefined : 0.25,
+        }}
+      >
+        <NextImage
+          src={Hexagon}
+          alt={`System Tile`}
+          fill
+          style={{ opacity: "10%", objectFit: "contain" }}
+        />
+      </div>
+    );
+  }
+
+  const parsedNum = parseInt(systemNumber);
+  if (parsedNum > 4200) {
+    systemNumber = (parsedNum - 3200).toString();
+  }
+  let classNames: string | undefined = "";
+  if (systemNumber.includes("A") && systemNumber.split("A").length > 1) {
+    classNames = getRotationClassFromNumber(
+      parseInt(systemNumber.split("A")[1] ?? "0")
+    );
+    systemNumber = `${systemNumber.split("A")[0] ?? ""}A`;
+  }
+  if (systemNumber.includes("B") && systemNumber.split("B").length > 1) {
+    classNames = getRotationClassFromNumber(
+      parseInt(systemNumber.split("B")[1] ?? "0")
+    );
+    systemNumber = `${systemNumber.split("B")[0] ?? ""}B`;
+  }
+
+  return (
+    <div
+      className={`flexRow ${classNames}`}
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        cursor: selectable ? "pointer" : undefined,
+        opacity: selectable ? undefined : 0.25,
+      }}
+      onClick={() => {
+        if (!systemNumber) {
+          return;
+        }
+        onClick(systemNumber);
+      }}
+    >
+      <NextImage
+        src={`/images/systems/ST_${systemNumber}.png`}
+        alt={`System ${systemNumber} Tile`}
+        fill
+        style={{ objectFit: "contain" }}
+      />
+    </div>
+  );
+}
+
+interface MapProps {
+  mapString: string;
+  mapStyle: MapStyle;
+  mallice?: string;
+  factions: {
+    id?: FactionId;
+    name?: string;
+    startswith?: {
+      faction?: FactionId;
+    };
+  }[];
+  canSelectSystem: (systemId: string) => boolean;
+  onSelect: (systemId: string) => void;
+}
+
+export default function SystemSelect({
+  mapString,
+  mapStyle,
+  mallice,
+  factions,
+  canSelectSystem,
+  onSelect,
+}: MapProps) {
+  const gameId = useContext(GameIdContext);
+
+  const updatedMapString = updateMapString(
+    mapString,
+    mapStyle,
+    factions.length
+  );
+  let updatedSystemTiles = ["18"].concat(updatedMapString.split(" "));
+  updatedSystemTiles = updatedSystemTiles.map((tile, index) => {
+    const updatedTile = updatedSystemTiles[index];
+    if (tile === "0" && updatedTile && updatedTile !== "0") {
+      const parsedTile = parseInt(updatedTile);
+      if (parsedTile > 4200) {
+        return (parsedTile - 3200).toString();
+      }
+      return updatedTile;
+    }
+    if (tile.startsWith("P")) {
+      const number = tile.at(tile.length - 1);
+      if (!number) {
+        return tile;
+      }
+      const factionIndex = parseInt(number);
+      return getFactionSystemNumber(factions[factionIndex - 1]);
+    }
+    return tile;
+  });
+
+  const numTiles = updatedSystemTiles.length;
+  let numRings = Math.ceil((3 + Math.sqrt(9 - 12 * (1 - numTiles))) / 6);
+  const largestDimension = numRings * 2 - 1;
+  const tilePercentage = 98 / largestDimension;
+
+  const spiral = cubeSpiral(Cube(0, 0, 0), numRings);
+
+  let ghosts = false;
+  let ghostsCorner = null;
+  factions.forEach((faction, index) => {
+    if (faction.id === "Ghosts of Creuss") {
+      switch (factions.length) {
+        case 3:
+          switch (index) {
+            case 0:
+              ghostsCorner = "top-right";
+              break;
+            case 1:
+              ghostsCorner = "bottom-right";
+              break;
+            case 2:
+              ghostsCorner = "top-left";
+              break;
+          }
+          break;
+        case 4:
+          switch (index) {
+            case 0:
+              ghostsCorner = mapStyle === "standard" ? "top-left" : "top-right";
+              break;
+            case 1:
+              ghostsCorner =
+                mapStyle === "standard" ? "top-right" : "bottom-right";
+              break;
+            case 2:
+              ghostsCorner =
+                mapStyle === "standard" ? "bottom-right" : "bottom-left";
+              break;
+            case 3:
+              ghostsCorner =
+                mapStyle === "standard" ? "bottom-left" : "top-left";
+              break;
+          }
+          break;
+        case 5:
+          switch (index) {
+            case 0:
+              ghostsCorner = "top-right";
+              break;
+            case 1:
+              ghostsCorner = "bottom-right";
+              break;
+            case 2:
+              ghostsCorner = "bottom-right";
+              break;
+            case 3:
+              ghostsCorner = "bottom-left";
+              break;
+            case 4:
+              ghostsCorner = "top-left";
+              break;
+          }
+          break;
+        case 6:
+          switch (index) {
+            case 0:
+            case 1:
+              ghostsCorner = "top-right";
+              break;
+            case 2:
+            case 3:
+              ghostsCorner = "bottom-right";
+              break;
+            case 4:
+              ghostsCorner = "bottom-left";
+              break;
+            case 5:
+              ghostsCorner = "top-left";
+              break;
+          }
+          break;
+        case 7:
+          switch (index) {
+            case 0:
+            case 1:
+              ghostsCorner = "top-right";
+              break;
+            case 2:
+            case 3:
+              ghostsCorner = "bottom-right";
+              break;
+            case 4:
+              ghostsCorner = "bottom-left";
+              break;
+            case 5:
+            case 6:
+              ghostsCorner = "top-left";
+              break;
+          }
+          break;
+        case 8:
+          switch (index) {
+            case 0:
+            case 1:
+              ghostsCorner = "top-right";
+              break;
+            case 2:
+            case 3:
+            case 4:
+              ghostsCorner = "bottom-right";
+              break;
+            case 5:
+              ghostsCorner = "bottom-left";
+              break;
+            case 6:
+            case 7:
+              ghostsCorner = "top-left";
+              break;
+          }
+          break;
+      }
+
+      ghosts = true;
+    }
+  });
+
+  return (
+    <div className={styles.Map}>
+      <div className={styles.SystemSelectBody}>
+        {spiral.map((cube, index) => {
+          const point = CubeToPixel(cube, tilePercentage * HEX_RATIO);
+          let tile = updatedSystemTiles[index];
+          if (!tile || tile === "-1") {
+            return null;
+          }
+          return (
+            <div
+              className="flexRow"
+              key={index}
+              style={{
+                position: "absolute",
+                width: `${tilePercentage * HEX_RATIO}%`,
+                height: `${tilePercentage}%`,
+                marginLeft: `${point.x}%`,
+                marginTop: `${point.y}%`,
+              }}
+            >
+              <SystemImage
+                gameId={gameId}
+                systemNumber={tile}
+                selectable={canSelectSystem(tile)}
+                onClick={onSelect}
+              />
+            </div>
+          );
+        })}
+        {ghosts ? (
+          <div
+            style={{
+              position: "absolute",
+              right:
+                ghostsCorner === "top-right" || ghostsCorner === "bottom-right"
+                  ? "4%"
+                  : undefined,
+              bottom:
+                ghostsCorner === "bottom-right" ||
+                ghostsCorner === "bottom-left"
+                  ? "4%"
+                  : undefined,
+              left:
+                ghostsCorner === "bottom-left" || ghostsCorner === "top-left"
+                  ? "4%"
+                  : undefined,
+              top:
+                ghostsCorner === "top-right" || ghostsCorner === "top-left"
+                  ? "4%"
+                  : undefined,
+              width: `${tilePercentage * HEX_RATIO}%`,
+              height: `${tilePercentage * HEX_RATIO}%`,
+            }}
+          >
+            <SystemImage
+              gameId={gameId}
+              systemNumber="51"
+              onClick={onSelect}
+              selectable={false}
+            />
+          </div>
+        ) : null}
+        {mallice ? (
+          <div
+            style={{
+              position: "absolute",
+              left: ghostsCorner !== "bottom-left" ? "4%" : undefined,
+              right: ghostsCorner === "bottom-left" ? "4%" : undefined,
+              bottom: "4%",
+              width: `${tilePercentage * HEX_RATIO}%`,
+              height: `${tilePercentage * HEX_RATIO}%`,
+            }}
+          >
+            <SystemImage
+              gameId={gameId}
+              systemNumber={mallice === "PURGED" ? "81" : `82${mallice}`}
+              selectable={canSelectSystem(
+                mallice === "PURGED" ? "81" : `82${mallice}`
+              )}
+              onClick={onSelect}
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TacticalAction.tsx
+++ b/src/components/TacticalAction.tsx
@@ -765,7 +765,6 @@ function AdjudicatorBaal() {
     if (!system) {
       return null;
     }
-    console.log(system.planets);
     const planetString = system.planets.join("/");
     return (
       <LabeledDiv label={adjudicatorBaal.name}>

--- a/src/components/TacticalAction.tsx
+++ b/src/components/TacticalAction.tsx
@@ -1,19 +1,35 @@
-import React, { CSSProperties, useContext } from "react";
+import React, { CSSProperties, useContext, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 import { ClientOnlyHoverMenu } from "../HoverMenu";
+import { InfoRow } from "../InfoRow";
+import { SelectableRow } from "../SelectableRow";
 import { TechRow } from "../TechRow";
+import {
+  ActionLogContext,
+  FactionContext,
+  GameIdContext,
+  LeaderContext,
+  OptionContext,
+  PlanetContext,
+  RelicContext,
+  SystemContext,
+} from "../context/Context";
 import {
   addAttachmentAsync,
   addTechAsync,
   claimPlanetAsync,
   loseRelicAsync,
+  playAdjudicatorBaalAsync,
   removeAttachmentAsync,
   removeTechAsync,
   scoreObjectiveAsync,
   unclaimPlanetAsync,
+  undoAdjudicatorBaalAsync,
   unscoreObjectiveAsync,
 } from "../dynamic/api";
 import { SymbolX } from "../icons/svgs";
 import {
+  getAdjudicatorBaalSystem,
   getAttachments,
   getGainedRelic,
   getObjectiveScorers,
@@ -23,21 +39,18 @@ import { hasTech } from "../util/api/techs";
 import { hasScoredObjective } from "../util/api/util";
 import { getFactionColor } from "../util/factions";
 import { applyPlanetAttachments } from "../util/planets";
+import AttachmentSelectRadialMenu from "./AttachmentSelectRadialMenu/AttachmentSelectRadialMenu";
 import FactionIcon from "./FactionIcon/FactionIcon";
 import FactionSelectRadialMenu from "./FactionSelectRadialMenu/FactionSelectRadialMenu";
+import FrontierExploration from "./FrontierExploration/FrontierExploration";
 import LabeledDiv from "./LabeledDiv/LabeledDiv";
 import LabeledLine from "./LabeledLine/LabeledLine";
-import PlanetRow from "./PlanetRow/PlanetRow";
+import SystemSelect from "./Map/SystemSelect";
 import ObjectiveRow from "./ObjectiveRow/ObjectiveRow";
-import styles from "./TacticalAction.module.scss";
-import AttachmentSelectRadialMenu from "./AttachmentSelectRadialMenu/AttachmentSelectRadialMenu";
 import PlanetIcon from "./PlanetIcon/PlanetIcon";
-import { FormattedMessage, useIntl } from "react-intl";
+import PlanetRow from "./PlanetRow/PlanetRow";
+import styles from "./TacticalAction.module.scss";
 import TechSelectHoverMenu from "./TechSelectHoverMenu/TechSelectHoverMenu";
-import FrontierExploration from "./FrontierExploration/FrontierExploration";
-import { GameIdContext, RelicContext } from "../context/Context";
-import { SelectableRow } from "../SelectableRow";
-import { InfoRow } from "../InfoRow";
 
 export function TacticalAction({
   activeFactionId,
@@ -702,6 +715,127 @@ export function TacticalAction({
           </ClientOnlyHoverMenu>
         </React.Fragment>
       ) : null}
+      {activeFactionId === "Embers of Muaat" ? <AdjudicatorBaal /> : null}
     </div>
+  );
+}
+
+function AdjudicatorBaal() {
+  const actionLog = useContext(ActionLogContext);
+  const factions = useContext(FactionContext);
+  const gameId = useContext(GameIdContext);
+  const options = useContext(OptionContext);
+  const leaders = useContext(LeaderContext);
+  const planets = useContext(PlanetContext);
+  const systems = useContext(SystemContext);
+
+  const [testing, setTesting] = useState(options["map-string"] ?? "");
+
+  let mallice;
+  if (options && (options["expansions"] ?? []).includes("POK")) {
+    const malliceObj = planets["Mallice"];
+    if (!malliceObj) {
+      mallice = "PURGED";
+    } else {
+      mallice = "A";
+    }
+    if (planets && (planets["Mallice"] ?? {}).owner) {
+      mallice = "B";
+    }
+  }
+
+  const mapOrderedFactions = Object.values(factions).sort(
+    (a, b) => a.mapPosition - b.mapPosition
+  );
+
+  const adjudicatorBaalSystem = getAdjudicatorBaalSystem(actionLog);
+
+  const mapString = options["map-string"];
+  if (!mapString) {
+    return null;
+  }
+
+  const adjudicatorBaal = leaders["Adjudicator Ba'al"];
+  if (!adjudicatorBaal) {
+    return null;
+  }
+
+  if (adjudicatorBaalSystem) {
+    const system = systems[adjudicatorBaalSystem];
+    if (!system) {
+      return null;
+    }
+    console.log(system.planets);
+    const planetString = system.planets.join("/");
+    return (
+      <LabeledDiv label={adjudicatorBaal.name}>
+        <SelectableRow
+          itemId={`${adjudicatorBaalSystem}`}
+          removeItem={() => {
+            undoAdjudicatorBaalAsync(gameId, adjudicatorBaalSystem);
+          }}
+          style={{ fontSize: "14px" }}
+        >
+          <FormattedMessage
+            id="dsGVrU"
+            defaultMessage="Replaced System {system}"
+            description="Message telling a player which system was replaced by the Muaat hero"
+            values={{ system: adjudicatorBaalSystem }}
+          />
+          {planetString !== "" ? ` (${planetString})` : ""}
+        </SelectableRow>
+      </LabeledDiv>
+    );
+  }
+
+  if (adjudicatorBaal.state !== "readied") {
+    return null;
+  }
+  return (
+    <ClientOnlyHoverMenu
+      label={adjudicatorBaal.name}
+      buttonStyle={{ fontSize: "14px" }}
+    >
+      <div
+        className="flexColumn"
+        style={{ width: "320px", height: "320px", marginBottom: "16px" }}
+      >
+        <SystemSelect
+          mapString={mapString}
+          mapStyle={options["map-style"]}
+          factions={mapOrderedFactions}
+          canSelectSystem={(systemId) => {
+            const systemNumber = parseInt(systemId);
+            if (
+              systemNumber < 19 ||
+              (systemNumber > 50 && systemNumber < 59) ||
+              (systemNumber > 80 && systemNumber < 82) ||
+              (systemNumber > 82 && systemNumber < 1037)
+            ) {
+              return false;
+            }
+            return true;
+          }}
+          onSelect={(systemId) => {
+            const systemNumber = parseInt(systemId);
+            if (!systemNumber) {
+              return;
+            }
+
+            if (
+              systemNumber < 19 ||
+              (systemNumber > 50 && systemNumber < 59) ||
+              (systemNumber > 80 && systemNumber < 82) ||
+              (systemNumber > 82 && systemNumber < 1037)
+            ) {
+              return;
+            }
+
+            playAdjudicatorBaalAsync(gameId, systemId as SystemId);
+          }}
+          mallice={mallice}
+        />
+      </div>
+    </ClientOnlyHoverMenu>
   );
 }

--- a/src/data/GameData.ts
+++ b/src/data/GameData.ts
@@ -510,7 +510,7 @@ export function buildPlanets(storedGameData: StoredGameData) {
     }
     // Maybe filter out PoK/DS systems. Only do it this way if not using the map to filter.
     if (
-      !isValidMapString &&
+      inGameSystems.length === 0 &&
       planet.expansion !== "BASE" &&
       planet.expansion !== "BASE ONLY" &&
       !gameOptions.expansions.includes(planet.expansion)

--- a/src/data/gameDataBuilder.ts
+++ b/src/data/gameDataBuilder.ts
@@ -393,7 +393,7 @@ export function buildPlanets(
     }
     // Maybe filter out PoK agendas.
     if (
-      !isValidMapString &&
+      inGameSystems.length === 0 &&
       planet.expansion !== "BASE" &&
       planet.expansion !== "BASE ONLY" &&
       !gameOptions.expansions.includes(planet.expansion)

--- a/src/dynamic/api.ts
+++ b/src/dynamic/api.ts
@@ -152,6 +152,7 @@ const updateLeaderStateFn = import("../util/api/updateLeaderState").then(
 const updatePlanetStateFn = import("../util/api/updatePlanetState").then(
   (mod) => mod.updatePlanetState
 );
+const playAdjudicatorBaalModule = import("../util/api/playAdjudicatorBaal");
 
 export async function addAttachmentAsync(
   gameId: string,
@@ -508,6 +509,14 @@ export async function unclaimPlanetAsync(
   unclaimPlanet(gameId, faction, planet);
 }
 
+export async function undoAdjudicatorBaalAsync(
+  gameId: string,
+  systemId: SystemId
+) {
+  const mod = await playAdjudicatorBaalModule;
+  mod.undoAdjudicatorBaal(gameId, systemId);
+}
+
 export async function unplayActionCardAsync(
   gameId: string,
   card: string,
@@ -572,4 +581,12 @@ export async function updatePlanetStateAsync(
 ) {
   const updatePlanetState = await updatePlanetStateFn;
   updatePlanetState(gameId, planet, state);
+}
+
+export async function playAdjudicatorBaalAsync(
+  gameId: string,
+  systemId: SystemId
+) {
+  const mod = await playAdjudicatorBaalModule;
+  mod.playAdjudicatorBaal(gameId, systemId);
 }

--- a/src/main/util/ComponentAction.tsx
+++ b/src/main/util/ComponentAction.tsx
@@ -38,7 +38,7 @@ import {
   selectFactionAsync,
   selectSubComponentAsync,
   unplayComponentAsync,
-  updatePlanetStateAsync
+  updatePlanetStateAsync,
 } from "../../dynamic/api";
 import {
   getClaimedPlanets,
@@ -48,14 +48,12 @@ import {
   getResearchedTechs,
   getScoredObjectives,
   getSelectedFaction,
-  getSelectedSubComponent
+  getSelectedSubComponent,
 } from "../../util/actionLog";
 import { getCurrentTurnLogEntries } from "../../util/api/actionLog";
 import { hasTech } from "../../util/api/techs";
 import { getFactionColor, getFactionName } from "../../util/factions";
-import {
-  applyAllPlanetAttachments
-} from "../../util/planets";
+import { applyAllPlanetAttachments } from "../../util/planets";
 import { pluralize } from "../../util/util";
 
 function capitalizeFirstLetter(string: string) {
@@ -1541,12 +1539,14 @@ export function ComponentAction({ factionId }: { factionId: FactionId }) {
           return false;
         }
 
-        if (
-          "leader" in component &&
-          component.leader === "HERO" &&
-          faction.hero !== "readied"
-        ) {
-          return false;
+        if ("leader" in component && component.leader === "HERO") {
+          const hero = leaders[component.id as LeaderId];
+          if (!hero) {
+            return false;
+          }
+          if (hero.state !== "readied") {
+            return false;
+          }
         }
 
         return true;

--- a/src/util/actionLog.ts
+++ b/src/util/actionLog.ts
@@ -222,3 +222,11 @@ export function getPlayedRelic(actionLog: ActionLogEntry[], relic: RelicId) {
     )
     .map((logEntry) => (logEntry.data as PlayRelicData).event)[0];
 }
+
+export function getAdjudicatorBaalSystem(actionLog: ActionLogEntry[]) {
+  return actionLog
+    .filter((logEntry) => logEntry.data.action === "PLAY_ADJUDICATOR_BAAL")
+    .map(
+      (logEntry) => (logEntry.data as PlayAdjudicatorBaalData).event.systemId
+    )[0];
+}

--- a/src/util/api/gameLog.ts
+++ b/src/util/api/gameLog.ts
@@ -25,6 +25,7 @@ import {
   PlayActionCardHandler,
   UnplayActionCardHandler,
 } from "../model/playActionCard";
+import { PlayAdjudicatorBaalHandler } from "../model/playAdjudicatorBaal";
 import {
   PlayComponentHandler,
   UnplayComponentHandler,
@@ -174,5 +175,7 @@ export function getHandler(gameData: StoredGameData, data: GameUpdateData) {
       return new UnswapStrategyCardsHandler(gameData, data);
     case "UPDATE_PLANET_STATE":
       return new UpdatePlanetStateHandler(gameData, data);
+    case "PLAY_ADJUDICATOR_BAAL":
+      return new PlayAdjudicatorBaalHandler(gameData, data);
   }
 }

--- a/src/util/api/opposite.ts
+++ b/src/util/api/opposite.ts
@@ -45,6 +45,7 @@ import { UnstartVotingHandler } from "../model/startVoting";
 import { UnswapStrategyCardsHandler } from "../model/swapStrategyCards";
 import { UpdateLeaderStateHandler } from "../model/updateLeaderState";
 import { UpdatePlanetStateHandler } from "../model/updatePlanetState";
+import { UndoAdjudicatorBaalHandler } from "../model/playAdjudicatorBaal";
 
 export function getOppositeHandler(
   gameData: StoredGameData,
@@ -413,5 +414,12 @@ export function getOppositeHandler(
     case "UNPLAY_RELIC": {
       throw new Error("UNPLAY_RELIC should not be in log");
     }
+    case "PLAY_ADJUDICATOR_BAAL":
+      return new UndoAdjudicatorBaalHandler(gameData, {
+        action: "UNDO_ADJUDICATOR_BAAL",
+        event: data.event,
+      });
+    case "UNDO_ADJUDICATOR_BAAL":
+      throw new Error("UNDO_ADJUDICATOR_BAAL should not be in log");
   }
 }

--- a/src/util/api/playAdjudicatorBaal.ts
+++ b/src/util/api/playAdjudicatorBaal.ts
@@ -1,0 +1,75 @@
+import { mutate } from "swr";
+import { BASE_GAME_DATA } from "../../../server/data/data";
+import { updateGameData } from "./handler";
+import { updateActionLog } from "./update";
+import { poster } from "./util";
+import {
+  PlayAdjudicatorBaalHandler,
+  UndoAdjudicatorBaalHandler,
+} from "../model/playAdjudicatorBaal";
+
+export function playAdjudicatorBaal(gameId: string, systemId: SystemId) {
+  const data: GameUpdateData = {
+    action: "PLAY_ADJUDICATOR_BAAL",
+    event: {
+      systemId,
+    },
+  };
+
+  mutate(
+    `/api/${gameId}/data`,
+    async () => await poster(`/api/${gameId}/dataUpdate`, data),
+    {
+      optimisticData: (currentData?: StoredGameData) => {
+        if (!currentData) {
+          return BASE_GAME_DATA;
+        }
+        const handler = new PlayAdjudicatorBaalHandler(currentData, data);
+
+        if (!handler.validate()) {
+          return currentData;
+        }
+
+        updateGameData(currentData, handler.getUpdates());
+
+        updateActionLog(currentData, handler);
+
+        return structuredClone(currentData);
+      },
+      revalidate: false,
+    }
+  );
+}
+
+export function undoAdjudicatorBaal(gameId: string, systemId: SystemId) {
+  const data: GameUpdateData = {
+    action: "UNDO_ADJUDICATOR_BAAL",
+    event: {
+      systemId,
+    },
+  };
+
+  mutate(
+    `/api/${gameId}/data`,
+    async () => await poster(`/api/${gameId}/dataUpdate`, data),
+    {
+      optimisticData: (currentData?: StoredGameData) => {
+        if (!currentData) {
+          return BASE_GAME_DATA;
+        }
+        const handler = new UndoAdjudicatorBaalHandler(currentData, data);
+
+        if (!handler.validate()) {
+          return currentData;
+        }
+
+        updateGameData(currentData, handler.getUpdates());
+
+        updateActionLog(currentData, handler);
+
+        return structuredClone(currentData);
+      },
+      revalidate: false,
+    }
+  );
+}

--- a/src/util/map.ts
+++ b/src/util/map.ts
@@ -123,7 +123,6 @@ export function isValidMapString(mapString: string, numFactions: number) {
   const systems = mapString.split(" ");
   for (const system of systems) {
     if (!validSystemNumber(system)) {
-      console.log(`${system} NOT VALID`);
       return false;
     }
     if (isHomeSystem(system)) {
@@ -131,7 +130,6 @@ export function isValidMapString(mapString: string, numFactions: number) {
     }
   }
   if (numFactionSystems !== numFactions) {
-    console.log(`${numFactionSystems} NOT VALID`);
     return false;
   }
   return true;

--- a/src/util/model/playAdjudicatorBaal.ts
+++ b/src/util/model/playAdjudicatorBaal.ts
@@ -1,0 +1,113 @@
+import { buildSystems } from "../../data/GameData";
+
+export class PlayAdjudicatorBaalHandler implements Handler {
+  constructor(
+    public gameData: StoredGameData,
+    public data: PlayAdjudicatorBaalData
+  ) {}
+
+  validate(): boolean {
+    return true;
+  }
+
+  getUpdates(): Record<string, any> {
+    let updates: Record<string, any> = {
+      [`state.paused`]: false,
+      [`leaders.Adjudicator Ba'al.state`]: "purged",
+    };
+
+    const newMapString = (this.gameData.options["map-string"] ?? "")
+      .split(" ")
+      .map((system) => {
+        if (system == this.data.event.systemId) {
+          return "81";
+        }
+        return system;
+      })
+      .join(" ");
+
+    updates[`options.map-string`] = newMapString;
+
+    const system = buildSystems(this.gameData)[this.data.event.systemId];
+    if (!system) {
+      return updates;
+    }
+
+    for (const planet of system.planets) {
+      updates[`planets.${planet}.state`] = "PURGED";
+    }
+
+    return updates;
+  }
+
+  getLogEntry(): ActionLogEntry {
+    return {
+      timestampMillis: Date.now(),
+      data: this.data,
+    };
+  }
+
+  getActionLogAction(entry: ActionLogEntry): ActionLogAction {
+    if (entry.data.action === "PLAY_ADJUDICATOR_BAAL") {
+      return "REPLACE";
+    }
+
+    return "IGNORE";
+  }
+}
+
+export class UndoAdjudicatorBaalHandler implements Handler {
+  constructor(
+    public gameData: StoredGameData,
+    public data: UndoAdjudicatorBaalData
+  ) {}
+
+  validate(): boolean {
+    return true;
+  }
+
+  getUpdates(): Record<string, any> {
+    let updates: Record<string, any> = {
+      [`state.paused`]: false,
+      [`leaders.Adjudicator Ba'al.state`]: "readied",
+    };
+
+    const newMapString = (this.gameData.options["map-string"] ?? "")
+      .split(" ")
+      .map((system) => {
+        if (system == "81") {
+          return this.data.event.systemId;
+        }
+        return system;
+      })
+      .join(" ");
+
+    updates[`options.map-string`] = newMapString;
+
+    const system = buildSystems(this.gameData)[this.data.event.systemId];
+    if (!system) {
+      return updates;
+    }
+
+    for (const planet of system.planets) {
+      updates[`planets.${planet}.state`] = "DELETE";
+    }
+
+    return updates;
+  }
+
+  getLogEntry(): ActionLogEntry {
+    return {
+      timestampMillis: Date.now(),
+      data: this.data,
+    };
+  }
+
+  getActionLogAction(entry: ActionLogEntry): ActionLogAction {
+    if (entry.data.action === "PLAY_ADJUDICATOR_BAAL") {
+      return "DELETE";
+    }
+
+    return "IGNORE";
+  }
+}

--- a/src/util/types/api.d.ts
+++ b/src/util/types/api.d.ts
@@ -50,6 +50,7 @@ type GameUpdateData =
   | SpeakerTieBreakData
   | StartVotingData
   | (PlayRelicData | UnplayRelicData)
+  | (PlayAdjudicatorBaalData | UndoAdjudicatorBaalData)
   // TODO
   | UndoData;
 
@@ -587,4 +588,18 @@ interface PlayRelicData {
 interface UnplayRelicData {
   action: "UNPLAY_RELIC";
   event: PlayRelicEvent;
+}
+
+interface AdjudicatorBaalEvent {
+  systemId: SystemId;
+}
+
+interface PlayAdjudicatorBaalData {
+  action: "PLAY_ADJUDICATOR_BAAL";
+  event: AdjudicatorBaalEvent;
+}
+
+interface UndoAdjudicatorBaalData {
+  action: "UNDO_ADJUDICATOR_BAAL";
+  event: AdjudicatorBaalEvent;
 }


### PR DESCRIPTION
Add ability to mark the usage of the Muaat hero, which will replace a system with the Muaat supernova and purge all the planets in that system.

Fix hero/agents getting marked as unlocked/used/purged/etc.

Update options menu to use a NumberInput for the Victory Points and the Toggle element for the expansions.