### PR TITLE
Add support for the Minor Factions scenario

### DIFF
--- a/app/map-builder/map-builder-page.tsx
+++ b/app/map-builder/map-builder-page.tsx
@@ -23,7 +23,8 @@ type Filter =
   | "NO_PLANETS"
   | "ONE_PLANET"
   | "TWO_PLANETS"
-  | "THREE_PLANETS";
+  | "THREE_PLANETS"
+  | "HOME_SYSTEMS";
 
 function getFilterButtonText(filter: Filter, intl: IntlShape) {
   switch (filter) {
@@ -53,6 +54,12 @@ function getFilterButtonText(filter: Filter, intl: IntlShape) {
         description:
           "Text on a button that will enable/disable the Discordant Stars expansion.",
         defaultMessage: "Discordant Stars",
+      });
+    case "HOME_SYSTEMS":
+      return intl.formatMessage({
+        id: "22b12K",
+        description: "Home system planets.",
+        defaultMessage: "Home",
       });
     case "NO_PLANETS":
       return 0;
@@ -175,6 +182,14 @@ export default function MapBuilderPage() {
       tileNumbers.push(i.toString());
     }
   }
+  if (filters.has("HOME_SYSTEMS")) {
+    for (let i = 1; i < 18; i++) {
+      tileNumbers.push(i.toString());
+    }
+    for (let i = 52; i < 59; i++) {
+      tileNumbers.push(i.toString());
+    }
+  }
 
   tileNumbers = tileNumbers.filter((number) => {
     const system = systems[number as SystemId];
@@ -277,6 +292,11 @@ export default function MapBuilderPage() {
                 />
                 <FilterButton
                   filter="DISCORDANT_STARS"
+                  filters={filters}
+                  setFilters={setFilters}
+                />
+                <FilterButton
+                  filter="HOME_SYSTEMS"
                   filters={filters}
                   setFilters={setFilters}
                 />

--- a/src/data/GameData.ts
+++ b/src/data/GameData.ts
@@ -471,7 +471,11 @@ export function buildPlanets(storedGameData: StoredGameData) {
 
   let planets = {} as Partial<Record<PlanetId, Planet>>;
   Object.entries(BASE_PLANETS).forEach(([_, planet]) => {
-    if (planet.faction && !gameFactions[planet.faction]) {
+    let isPlanetInMap = planet.system && inGameSystems.includes(planet.system);
+    if (planet.id === "Creuss" && inGameSystems.includes(17)) {
+      isPlanetInMap = true;
+    }
+    if (planet.faction && !gameFactions[planet.faction] && !isPlanetInMap) {
       if (!gameFactions["Council Keleres"]) {
         return;
       }
@@ -491,12 +495,12 @@ export function buildPlanets(storedGameData: StoredGameData) {
     if (
       validMapString &&
       inGameSystems.length > 0 &&
+      !isPlanetInMap &&
       planet.system &&
       planet.id !== "Mirage" &&
       planet.id !== "Mallice" &&
       planet.id !== "Mecatol Rex" &&
-      !planet.faction &&
-      !inGameSystems.includes(planet.system)
+      !planet.faction
     ) {
       // TODO: Remove once Milty Draft site fixes numbering
       if (typeof planet.system === "number") {

--- a/src/data/gameDataBuilder.ts
+++ b/src/data/gameDataBuilder.ts
@@ -354,7 +354,11 @@ export function buildPlanets(
 
   let planets = {} as Partial<Record<PlanetId, Planet>>;
   Object.entries(baseData.planets).forEach(([_, planet]) => {
-    if (planet.faction && !gameFactions[planet.faction]) {
+    let isPlanetInMap = planet.system && inGameSystems.includes(planet.system);
+    if (planet.id === "Creuss" && inGameSystems.includes(17)) {
+      isPlanetInMap = true;
+    }
+    if (planet.faction && !gameFactions[planet.faction] && !isPlanetInMap) {
       if (!gameFactions["Council Keleres"]) {
         return;
       }
@@ -374,12 +378,12 @@ export function buildPlanets(
     if (
       validMapString &&
       inGameSystems.length > 0 &&
+      !isPlanetInMap &&
       planet.system &&
       planet.id !== "Mirage" &&
       planet.id !== "Mallice" &&
       planet.id !== "Mecatol Rex" &&
-      !planet.faction &&
-      !inGameSystems.includes(planet.system)
+      !planet.faction
     ) {
       // TODO: Remove once Milty Draft site fixes numbering
       if (typeof planet.system === "number") {


### PR DESCRIPTION
Home system planets will no longer be filtered out if they are present in the map string.

Map builder now includes home systems.

Ghosts home system will appear when the Creuss gate is present on the map.