### PR TITLE
Add Age of Exploration scenario support

### DIFF
--- a/app/api/[gameId]/dataUpdate/route.ts
+++ b/app/api/[gameId]/dataUpdate/route.ts
@@ -101,6 +101,7 @@ import {
   UndoAdjudicatorBaalHandler,
   PlayAdjudicatorBaalHandler,
 } from "../../../../src/util/model/playAdjudicatorBaal";
+import { SwapMapTilesHandler } from "../../../../src/util/model/swapMapTiles";
 
 export async function POST(
   req: Request,
@@ -504,6 +505,9 @@ function updateInTransaction(
         break;
       case "UNDO_ADJUDICATOR_BAAL":
         handler = new UndoAdjudicatorBaalHandler(gameData, data);
+        break;
+      case "SWAP_MAP_TILES":
+        handler = new SwapMapTilesHandler(gameData, data);
         break;
       case "UNDO": {
         const actionToUndo = (gameData.actionLog ?? [])[0];

--- a/app/map-builder/map-builder-page.tsx
+++ b/app/map-builder/map-builder-page.tsx
@@ -177,16 +177,25 @@ export default function MapBuilderPage() {
       tileNumbers.push(`${i}B${rotation !== 0 ? rotation : ""}`);
     }
   }
-  if (filters.has("DISCORDANT_STARS")) {
-    for (let i = 1037; i < 1061; i++) {
-      tileNumbers.push(i.toString());
+  if (filters.has("HOME_SYSTEMS")) {
+    if (filters.has("BASE_GAME")) {
+      for (let i = 1; i < 18; i++) {
+        tileNumbers.push(i.toString());
+      }
+    }
+    if (filters.has("PROPHECY_OF_KINGS")) {
+      for (let i = 52; i < 59; i++) {
+        tileNumbers.push(i.toString());
+      }
+    }
+    if (filters.has("DISCORDANT_STARS")) {
+      for (let i = 1001; i < 1035; i++) {
+        tileNumbers.push(i.toString());
+      }
     }
   }
-  if (filters.has("HOME_SYSTEMS")) {
-    for (let i = 1; i < 18; i++) {
-      tileNumbers.push(i.toString());
-    }
-    for (let i = 52; i < 59; i++) {
+  if (filters.has("DISCORDANT_STARS")) {
+    for (let i = 1037; i < 1061; i++) {
       tileNumbers.push(i.toString());
     }
   }

--- a/app/setup/setup-page.tsx
+++ b/app/setup/setup-page.tsx
@@ -340,6 +340,30 @@ function MobileOptions({
                   ></input>
                 </div>
               </div>
+              <div>
+                Scenarios:
+                <div
+                  className="flexRow"
+                  style={{ alignItems: "flex-start", padding: "8px 20px" }}
+                >
+                  <Toggle
+                    selected={options.scenario === "AGE_OF_EXPLORATION"}
+                    toggleFn={(prevValue) => {
+                      if (prevValue) {
+                        toggleOption(undefined, "scenario");
+                      } else {
+                        toggleOption("AGE_OF_EXPLORATION", "scenario");
+                      }
+                    }}
+                  >
+                    <FormattedMessage
+                      id="sZua2x"
+                      defaultMessage="Age of Exploration"
+                      description="Name of scenario in which players can add new tiles to the map."
+                    />
+                  </Toggle>
+                </div>
+              </div>
               {/* {isCouncil ? (
                 <div>
                   Council Keleres:
@@ -697,6 +721,30 @@ function Options({
                 </div>
               </div>
             ) : null} */}
+            <div>
+              Scenarios:
+              <div
+                className="flexRow"
+                style={{ alignItems: "flex-start", padding: "8px 20px" }}
+              >
+                <Toggle
+                  selected={options.scenario === "AGE_OF_EXPLORATION"}
+                  toggleFn={(prevValue) => {
+                    if (prevValue) {
+                      toggleOption(undefined, "scenario");
+                    } else {
+                      toggleOption("AGE_OF_EXPLORATION", "scenario");
+                    }
+                  }}
+                >
+                  <FormattedMessage
+                    id="sZua2x"
+                    defaultMessage="Age of Exploration"
+                    description="Name of scenario in which players can add new tiles to the map."
+                  />
+                </Toggle>
+              </div>
+            </div>
             {variants.length > 1 ? (
               <div>
                 Variants (WIP):

--- a/server/compiled-lang/en.json
+++ b/server/compiled-lang/en.json
@@ -11382,6 +11382,12 @@
       "value": "count"
     }
   ],
+  "sZua2x": [
+    {
+      "type": 0,
+      "value": "Age of Exploration"
+    }
+  ],
   "sgqLYB": [
     {
       "type": 0,

--- a/server/lang/en.json
+++ b/server/lang/en.json
@@ -5911,6 +5911,10 @@
     "defaultMessage": "{count} {count, plural, one {Cruiser} other {Cruisers}}",
     "description": "A number of Cruiser units."
   },
+  "sZua2x": {
+    "defaultMessage": "Age of Exploration",
+    "description": "Name of scenario in which players can add new tiles to the map."
+  },
   "sgqLYB": {
     "defaultMessage": "Other",
     "description": "Text on a button used to select a non-listed value"

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -158,7 +158,7 @@ const FACTION_TO_SYSTEM_NUMBER: Record<FactionId, string> = {
   "Zelian Purifier": "1034",
 } as const;
 
-function getFactionSystemNumber(
+export function getFactionSystemNumber(
   faction:
     | {
         id?: FactionId;
@@ -525,6 +525,7 @@ interface MapProps {
       faction?: FactionId;
     };
   }[];
+  hideLegend?: boolean;
 }
 
 // const IMAGES_TO_PRELOAD = [
@@ -658,6 +659,7 @@ export default function Map({
   mapStyle,
   mallice,
   factions,
+  hideLegend,
 }: MapProps) {
   const gameId = useContext(GameIdContext);
 
@@ -833,7 +835,7 @@ export default function Map({
 
   return (
     <div className={styles.Map}>
-      {gameId ? (
+      {gameId && !hideLegend ? (
         <div className={styles.Legend}>
           <LabeledDiv
             label={

--- a/src/data/GameData.ts
+++ b/src/data/GameData.ts
@@ -289,6 +289,17 @@ export function buildComponents(
       };
     });
 
+  if (storedGameData.options.scenario === "AGE_OF_EXPLORATION") {
+    components["Dark Energy Tap"] = {
+      description:
+        "ACTION: You may exhaust DARK ENERGY TAP and roll 1 die. On a result of 1-4, draw a random unused red tile, on a result of 5-10, draw a random unused blue tile; place that tile adjacent to any border system that contains your ships. Place a frontier token in the newly placed system if it does not contain any planets.",
+      expansion: "BASE", // TODO: Add expansion when it comes out.
+      id: "Dark Energy Tap",
+      name: "Age of Exploration",
+      type: "TECH",
+    };
+  }
+
   Object.values(components).forEach((component) => {
     if (component.replaces) {
       delete components[component.replaces];

--- a/src/data/gameDataBuilder.ts
+++ b/src/data/gameDataBuilder.ts
@@ -218,6 +218,17 @@ export function buildComponents(
       };
     });
 
+  if (storedGameData.options.scenario === "AGE_OF_EXPLORATION") {
+    components["Dark Energy Tap"] = {
+      description:
+        "ACTION: You may exhaust DARK ENERGY TAP and roll 1 die. On a result of 1-4, draw a random unused red tile, on a result of 5-10, draw a random unused blue tile; place that tile adjacent to any border system that contains your ships. Place a frontier token in the newly placed system if it does not contain any planets.",
+      expansion: "BASE", // TODO: Add expansion when it comes out.
+      id: "Dark Energy Tap",
+      name: "Age of Exploration",
+      type: "TECH",
+    };
+  }
+
   Object.values(components).forEach((component) => {
     if (component.replaces) {
       delete components[component.replaces];

--- a/src/dynamic/api.ts
+++ b/src/dynamic/api.ts
@@ -153,6 +153,7 @@ const updatePlanetStateFn = import("../util/api/updatePlanetState").then(
   (mod) => mod.updatePlanetState
 );
 const playAdjudicatorBaalModule = import("../util/api/playAdjudicatorBaal");
+const swapMapTilesModule = import("../util/api/swapMapTiles");
 
 export async function addAttachmentAsync(
   gameId: string,
@@ -483,6 +484,21 @@ export async function speakerTieBreakAsync(gameId: string, tieBreak: string) {
 export async function startVotingAsync(gameId: string) {
   const startVoting = await startVotingFn;
   startVoting(gameId);
+}
+
+export async function swapMapTilesAsync(
+  gameId: string,
+  oldItem: {
+    systemNumber: string;
+    index: number;
+  },
+  newItem: {
+    systemNumber: string;
+    index: number;
+  }
+) {
+  const mod = await swapMapTilesModule;
+  mod.swapMapTiles(gameId, oldItem, newItem);
 }
 
 export async function swapStrategyCardsAsync(

--- a/src/util/actionLog.ts
+++ b/src/util/actionLog.ts
@@ -230,3 +230,10 @@ export function getAdjudicatorBaalSystem(actionLog: ActionLogEntry[]) {
       (logEntry) => (logEntry.data as PlayAdjudicatorBaalData).event.systemId
     )[0];
 }
+
+export function wereTilesSwapped(actionLog: ActionLogEntry[]) {
+  return (
+    actionLog.filter((logEntry) => logEntry.data.action === "SWAP_MAP_TILES")
+      .length > 0
+  );
+}

--- a/src/util/api/gameLog.ts
+++ b/src/util/api/gameLog.ts
@@ -60,6 +60,7 @@ import { SelectSubComponentHandler } from "../model/selectSubComponent";
 import { SetObjectivePointsHandler } from "../model/setObjectivePoints";
 import { SetSpeakerHandler } from "../model/setSpeaker";
 import { SpeakerTieBreakHandler } from "../model/speakerTieBreak";
+import { SwapMapTilesHandler } from "../model/swapMapTiles";
 import {
   SwapStrategyCardsHandler,
   UnswapStrategyCardsHandler,
@@ -177,5 +178,7 @@ export function getHandler(gameData: StoredGameData, data: GameUpdateData) {
       return new UpdatePlanetStateHandler(gameData, data);
     case "PLAY_ADJUDICATOR_BAAL":
       return new PlayAdjudicatorBaalHandler(gameData, data);
+    case "SWAP_MAP_TILES":
+      return new SwapMapTilesHandler(gameData, data);
   }
 }

--- a/src/util/api/opposite.ts
+++ b/src/util/api/opposite.ts
@@ -46,6 +46,7 @@ import { UnswapStrategyCardsHandler } from "../model/swapStrategyCards";
 import { UpdateLeaderStateHandler } from "../model/updateLeaderState";
 import { UpdatePlanetStateHandler } from "../model/updatePlanetState";
 import { UndoAdjudicatorBaalHandler } from "../model/playAdjudicatorBaal";
+import { SwapMapTilesHandler } from "../model/swapMapTiles";
 
 export function getOppositeHandler(
   gameData: StoredGameData,
@@ -421,5 +422,19 @@ export function getOppositeHandler(
       });
     case "UNDO_ADJUDICATOR_BAAL":
       throw new Error("UNDO_ADJUDICATOR_BAAL should not be in log");
+    case "SWAP_MAP_TILES":
+      return new SwapMapTilesHandler(gameData, {
+        action: "SWAP_MAP_TILES",
+        event: {
+          oldItem: {
+            systemNumber: data.event.newItem.systemNumber,
+            index: data.event.oldItem.index,
+          },
+          newItem: {
+            systemNumber: data.event.oldItem.systemNumber,
+            index: data.event.newItem.index,
+          },
+        },
+      });
   }
 }

--- a/src/util/api/swapMapTiles.ts
+++ b/src/util/api/swapMapTiles.ts
@@ -1,0 +1,50 @@
+import { mutate } from "swr";
+import { BASE_GAME_DATA } from "../../../server/data/data";
+import { updateGameData } from "./handler";
+import { updateActionLog } from "./update";
+import { poster } from "./util";
+import { SwapMapTilesHandler } from "../model/swapMapTiles";
+
+export function swapMapTiles(
+  gameId: string,
+  oldItem: {
+    systemNumber: string;
+    index: number;
+  },
+  newItem: {
+    systemNumber: string;
+    index: number;
+  }
+) {
+  const data: GameUpdateData = {
+    action: "SWAP_MAP_TILES",
+    event: {
+      oldItem,
+      newItem,
+    },
+  };
+
+  mutate(
+    `/api/${gameId}/data`,
+    async () => await poster(`/api/${gameId}/dataUpdate`, data),
+    {
+      optimisticData: (currentData?: StoredGameData) => {
+        if (!currentData) {
+          return BASE_GAME_DATA;
+        }
+        const handler = new SwapMapTilesHandler(currentData, data);
+
+        if (!handler.validate()) {
+          return currentData;
+        }
+
+        updateGameData(currentData, handler.getUpdates());
+
+        updateActionLog(currentData, handler);
+
+        return structuredClone(currentData);
+      },
+      revalidate: false,
+    }
+  );
+}

--- a/src/util/model/playComponent.ts
+++ b/src/util/model/playComponent.ts
@@ -147,6 +147,14 @@ export class UnplayComponentHandler implements Handler {
         ...updateLeaderStateHandler.getUpdates(),
       };
     }
+    if (component.type === "TECH") {
+      const state = buildState(this.gameData);
+      if (state.activeplayer && state.activeplayer !== "None") {
+        updates[
+          `factions.${state.activeplayer}.techs.${this.data.event.name}.ready`
+        ] = true;
+      }
+    }
 
     if (this.data.event.name === "Ul the Progenitor") {
       const handler = new RemoveAttachmentHandler(this.gameData, {

--- a/src/util/model/swapMapTiles.ts
+++ b/src/util/model/swapMapTiles.ts
@@ -1,0 +1,51 @@
+export class SwapMapTilesHandler implements Handler {
+  constructor(public gameData: StoredGameData, public data: SwapMapTilesData) {}
+
+  validate(): boolean {
+    return true;
+  }
+
+  getUpdates(): Record<string, any> {
+    let updates: Record<string, any> = {
+      [`state.paused`]: false,
+    };
+
+    const systems = (this.gameData.options["map-string"] ?? "").split(" ");
+
+    while (
+      systems.length < this.data.event.newItem.index - 1 ||
+      systems.length < this.data.event.oldItem.index - 1
+    ) {
+      systems.push("-1");
+    }
+
+    systems[this.data.event.oldItem.index - 1] =
+      this.data.event.newItem.systemNumber;
+
+    systems[this.data.event.newItem.index - 1] =
+      this.data.event.oldItem.systemNumber;
+
+    while (systems.length > 0 && systems[systems.length - 1] === "-1") {
+      systems.pop();
+    }
+
+    updates[`options.map-string`] = systems.join(" ");
+
+    return updates;
+  }
+
+  getLogEntry(): ActionLogEntry {
+    return {
+      timestampMillis: Date.now(),
+      data: this.data,
+    };
+  }
+
+  getActionLogAction(entry: ActionLogEntry): ActionLogAction {
+    if (entry.data.action === "SWAP_MAP_TILES") {
+      return "DELETE";
+    }
+
+    return "IGNORE";
+  }
+}

--- a/src/util/types/api.d.ts
+++ b/src/util/types/api.d.ts
@@ -51,6 +51,7 @@ type GameUpdateData =
   | StartVotingData
   | (PlayRelicData | UnplayRelicData)
   | (PlayAdjudicatorBaalData | UndoAdjudicatorBaalData)
+  | SwapMapTilesData
   // TODO
   | UndoData;
 
@@ -602,4 +603,20 @@ interface PlayAdjudicatorBaalData {
 interface UndoAdjudicatorBaalData {
   action: "UNDO_ADJUDICATOR_BAAL";
   event: AdjudicatorBaalEvent;
+}
+
+interface SwapMapTilesEvent {
+  oldItem: {
+    systemNumber: string;
+    index: number;
+  };
+  newItem: {
+    systemNumber: string;
+    index: number;
+  };
+}
+
+interface SwapMapTilesData {
+  action: "SWAP_MAP_TILES";
+  event: SwapMapTilesEvent;
 }

--- a/src/util/types/options.d.ts
+++ b/src/util/types/options.d.ts
@@ -7,6 +7,8 @@ type Expansion =
   | "DISCORDANT STARS"
   | "BASE ONLY";
 
+type Scenario = "AGE_OF_EXPLORATION";
+
 type OptionUpdateAction = "SET_OPTION";
 
 interface OptionUpdateData {
@@ -24,5 +26,6 @@ interface Options {
   "map-string"?: string;
   "map-style": MapStyle;
   "victory-points": number;
+  scenario?: Scenario;
   [key: string]: any;
 }

--- a/src/util/types/setup.d.ts
+++ b/src/util/types/setup.d.ts
@@ -13,6 +13,7 @@ interface SetupOptions {
   "hide-objectives": boolean;
   "hide-planets": boolean;
   "hide-techs": boolean;
+  scenario?: Scenario;
   [key: string]: any;
 }
 


### PR DESCRIPTION
Changes:

- During setup, Age of Exploration can be selected in the options menu.
- Players with Dark Energy Tap can select Age of Exploration in the Techs menu of Components.
- After selecting Age of Exploration, the player can add an unused system tile to the map.