### PR TITLE
Map builder usabililty

### DIFF
--- a/app/map-builder/map-builder-page.tsx
+++ b/app/map-builder/map-builder-page.tsx
@@ -150,6 +150,16 @@ function mapValuePriority(a?: string, b?: string) {
   if (b === "0") {
     return a;
   }
+
+  const isPA = /^P\d+$/.test(a);
+  const isPB = /^P\d+$/.test(b);
+  if (isPA && !isPB) {
+    return b;
+  }
+  if (!isPA && isPB) {
+    return a;
+  }
+
   return a;
 }
 

--- a/src/util/model/swapMapTiles.ts
+++ b/src/util/model/swapMapTiles.ts
@@ -108,5 +108,15 @@ function mapValuePriority(a?: string, b?: string) {
   if (b === "0") {
     return a;
   }
+
+  const isPA = /^P\d+$/.test(a);
+  const isPB = /^P\d+$/.test(b);
+  if (isPA && !isPB) {
+    return b;
+  }
+  if (!isPA && isPB) {
+    return a;
+  }
+
   return a;
 }


### PR DESCRIPTION
1. Switch to onblur, map string is only reprocessed when user clicks out of the text box (preventing random resetting)
2. If the user provides proper home systems In the map string, treat them properly (instead of just overwriting them with Px's)