### PR TITLE
fix: modify overzealous TF filter

### DIFF
--- a/app/game/[gameId]/main/@phase/action/ComponentAction.tsx
+++ b/app/game/[gameId]/main/@phase/action/ComponentAction.tsx
@@ -176,7 +176,7 @@ function ComponentSelect({
     )
     .filter(
       (component) =>
-        component.type !== "ABILITY" || component.owner === factionId
+        component.type !== "ABILITY" || component.owner === factionId || component.faction === factionId
     )
     .sort((a, b) => (a.name > b.name ? 1 : -1));
 


### PR DESCRIPTION
Just played a game today: and looks like this filter eagerly filters out all component actions on faction sheets (namely Puppets of the Blade, but also applied to Orbital Drop + Stall Tactics in my testing)

This looks like it fixes on my local.